### PR TITLE
Add support for known background-based normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Full support for genomes with multiple contigs/chromosomes ([#5](https://github.com/mikewolfe/ChIPseq_pipeline/issues/5))
 - Full support of masking regions of the genome from analysis ([#11](https://github.com/mikewolfe/ChIPseq_pipeline/issues/11))
+- Full support for normalization based on a known background region ([#6](https://github.com/mikewolfe/ChIPseq_pipeline/issues/6))
 
 ### Changed
 - Config syntax for specifying genome inputs


### PR DESCRIPTION
Adding ability to do background normalization based on a specified region of the chromosome. This is not data-driven at all, rather you, must have prior information that the regions specified should have background levels of ChIP signal.

The normalization will subtract the average of the background regions from the total signal. Nans are ignored in the mean calculation. It can also then scale the final signal by the max signal (average of the top 1000 bins in the data, Nans ignored) in the overall track (over all contigs). 

This normalization is controlled by a `background_subtraction` header in the `config.yaml` file. Under that header a region for all samples can be specified with `background_regions: "path_to_file_name"`.

Future development can add data-driven background determination or different background regions based on filters in the ChIP metadata.