### PR TITLE
Add support for subtracting rather than dividing input samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Next
+
+### Added
+- Support for subtracting rather than dividing the input from the extracted
+
+### Changed
+- Refactored the config file syntax to be more general for `peak_calling`
+
 ## 0.1.1 - 2021-06-03
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Next
+## 0.2.0 - 2021-09-08
 
 ### Added
 - Support for subtracting rather than dividing the input from the extracted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Support for subtracting rather than dividing the input from the extracted
+- A summarize method for `bwtools` that gives total signal per contig
 
 ### Changed
 - Refactored the config file syntax to be more general for `peak_calling`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Refactored the config file syntax to be more general for `peak_calling`
+- Moved output of ext to inp comparisions from `results/coverage_and_norm/deeptools_log2ratio/` to `bwtools_compare/`
 
 ## 0.1.1 - 2021-06-03
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ If you run into any issues with the pipeline and would like help please submit i
 
 # Version history
 
-Currently at version 0.1.1
+Currently at version 0.2.0
 
 See the [Changelog](CHANGELOG.md) for version history and upcoming
 features.

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -105,7 +105,7 @@ peak_calling:
         # filter out the samples you want to run based on metadata
         filter: 'not input_sample.isnull()'
         # Choose which coverage file you want to run the peak caller on
-        filesignature: "results/coverage_and_norm/deeptools_log2ratio/%s_BPM_subinp.bw"
+        filesignature: "results/coverage_and_norm/bwtools_compare/%s_BPM_log2ratio.bw"
         # Window size is required for cmarrt
         # Half the size of the window in *entries* thus this would be 25
         # * 5 bp resolution for a half window size of 125 bp
@@ -139,7 +139,7 @@ postprocessing:
             regions: "results/alignment/process_genbank/U00096.3/U00096.3.bed"
             # which files to use? This file signature will substitute in
             # a sample name for the %s
-            filesignature: "results/coverage_and_norm/deeptools_log2ratio/%s_median_log2ratio_querysub_queryscale.bw"
+            filesignature: "results/coverage_and_norm/bwtools_compare/%s_median_log2ratio_querysub_queryscale.bw"
             # how many bp upstream (5') of a feature to include
             upstream: 0
             # how many bp downstream (3') of a feature to include
@@ -157,7 +157,7 @@ postprocessing:
             # which regions to use?
             regions: "results/alignment/process_genbank/U00096.3/U00096.3.bed"
             # which files to use?
-            filesignature: "results/coverage_and_norm/deeptools_log2ratio/%s_median_log2ratio_querysub_queryscale.bw"
+            filesignature: "results/coverage_and_norm/bwtools_compare/%s_median_log2ratio_querysub_queryscale.bw"
             # what resolution to query data (shouldn't be lower than the
             # resolution of your file
             res : 5

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -19,36 +19,27 @@ reference:
             # but you can also add additional contigs that you may want in
             # the final alignment genome by listing them here
             - test/ecoli_rrnD.fa
+        # This allows you to mask regions by replacing them with Ns. Masked
+        # regions need to be specified by a bed file
         masked_regions: test/ecoli_rrns.bed
-
-
-    # name of the genome
-    U00096.3_and_bsub:
-        # location of the genbanks. If put in the location and format shown
-        # below the pipeline will attempt to pull this file from NCBI by
-        # accession number. Each genbank MUST have a associated name which
-        # is used to name the contig pulled from it.
-        genbanks: 
-            U00096.3: resources/genbanks/U00096.3.gbk
-            AL009126.3: resources/genbanks/AL009126.3.gbk
-        # This is the fasta file for each chromosome in the genome
-        # If specified location then it is automatically parsed
-        # from the genbank.
-        fastas:
-            - results/alignment/process_genbank/U00096.3_and_bsub/U00096.3.fna
-            - results/alignment/process_genbank/U00096.3_and_bsub/AL009126.3.fna
-            # but you can also add additional contigs that you may want in
-            # the final alignment genome by listing them here
-            - test/ecoli_rrnD.fa
-        masked_regions: test/ecoli_rrns.bed
-        spike_in:
-            - results/alignment/process_genbank/U00096.3_and_bsub/AL0009126.3.fna
 
 # Options to control preprocessing rules
 preprocessing:
+    # control the parameter string passed to cutadapt. Here you could change
+    # the adaptor sequences for every sample by using 
+    # cut_param_string:
+    #   value: "my string here"
+    # or by sample by using :
+    # cut_param_string: 
+    #   column: cutadapt_params
+    # and specifying the name of the column in the
+    # sample sheet that holds the strings you want to for each sample. In this
+    # example it would be the column cutadapt_params that holds a string for
+    # each sample
     cutadapt_pe:
         cut_param_string:
             value: "-a AGATCGGAAGAGCACACGTCTGAACTCCAGTCA -A AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT"
+    # Control the parameter string from trimmomatic
     trimmomatic_pe:
         trim_param_string:
             value: "LEADING:3 TRAILING:3 SLIDINGWINDOW:4:15"
@@ -56,14 +47,18 @@ preprocessing:
 # Options to control alignment rules
 alignment:
     process_genbank:
+        # Control what features are parsed from the genbank when pulling out
+        # bed files
         features:
             value: "CDS tRNA rRNA ncRNA"
         qual_name: 
             value: "gene"
-
     bowtie2_map:
+        # controls how bowtie2 does its alignments
         bowtie2_param_string:
             value: "--end-to-end --very-sensitive --phred33"
+        # controls samtools filtering as reads come out of bowtie2. Default
+        # is to just convert the sam records into a bam with -b
         samtools_view_param_string:
             value: "-b"
 
@@ -143,6 +138,9 @@ peak_calling:
         peak_caller: "macs2"
         # filter out the samples you want to run based on metadata
         filter: 'not input_sample.isnull()'
+        # Macs2 runs directly on the bam files for each sample so
+        # a filesignature does not need to specified.
+
         # specify a parameter string used to control macs2
         # -f BAMPE is automatically specified and -g EFFECTIVE_GENOME_SIZE is
         # automatically determined.
@@ -188,5 +186,6 @@ postprocessing:
             # point in tidy format, single allows for a single number summary)
             summarize: "single"
             # What single number summary do you want (mean, median, max, min)
+            # only defined when summarize is "single"
             summarize_func: "mean"
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -21,6 +21,29 @@ reference:
             - test/ecoli_rrnD.fa
         masked_regions: test/ecoli_rrns.bed
 
+
+    # name of the genome
+    U00096.3_and_bsub:
+        # location of the genbanks. If put in the location and format shown
+        # below the pipeline will attempt to pull this file from NCBI by
+        # accession number. Each genbank MUST have a associated name which
+        # is used to name the contig pulled from it.
+        genbanks: 
+            U00096.3: resources/genbanks/U00096.3.gbk
+            AL009126.3: resources/genbanks/AL009126.3.gbk
+        # This is the fasta file for each chromosome in the genome
+        # If specified location then it is automatically parsed
+        # from the genbank.
+        fastas:
+            - results/alignment/process_genbank/U00096.3_and_bsub/U00096.3.fna
+            - results/alignment/process_genbank/U00096.3_and_bsub/AL009126.3.fna
+            # but you can also add additional contigs that you may want in
+            # the final alignment genome by listing them here
+            - test/ecoli_rrnD.fa
+        masked_regions: test/ecoli_rrns.bed
+        spike_in:
+            - results/alignment/process_genbank/U00096.3_and_bsub/AL0009126.3.fna
+
 # Options to control preprocessing rules
 preprocessing:
     cutadapt_pe:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -98,23 +98,33 @@ quality_control:
 
 # Options to control peak calling
 peak_calling:
-        # Options that control CMARRT calling
-    cmarrt:
-            # Can specify individual parameters based on a column
-        group_by: genome
-            # for each value in the column specify the parameters
-        U00096.3:
-                # Half the size of the window in *entries* thus this would be 25
-                # * 5 bp resolution for a half window size of 125 bp
-            wi: 25
-                # Number of entries to consolidate peaks over i.e. two peaks within
-                # 10 * 5bp = 50 bp will get merged into one peak.
-            consolidate: 10
-    macs2:
-        group_by: genome
-        U00096.3:
-            # call broad peaks?
-            broad: true
+    # Can make different models to try out different peak callers or parameters
+    cmarrt_all:
+        # specify the peak caller to use. Currently only support "cmarrt" and "macs2"
+        peak_caller: "cmarrt"
+        # filter out the samples you want to run based on metadata
+        filter: 'not input_sample.isnull()'
+        # Choose which coverage file you want to run the peak caller on
+        filesignature: "results/coverage_and_norm/deeptools_log2ratio/%s_BPM_subinp.bw"
+        # Window size is required for cmarrt
+        # Half the size of the window in *entries* thus this would be 25
+        # * 5 bp resolution for a half window size of 125 bp
+        cmarrt_window_size:
+            value: 25
+        # Additional parameters to the calling function can be specified here
+        # Number of entries to consolidate peaks over i.e. two peaks within
+        # 10 * 5bp = 50 bp will get merged into one peak.
+        cmarrt_param_string:
+            value:  "--consolidate 10 --plots"
+    macs2_all:
+        peak_caller: "macs2"
+        # filter out the samples you want to run based on metadata
+        filter: 'not input_sample.isnull()'
+        # specify a parameter string used to control macs2
+        # -f BAMPE is automatically specified and -g EFFECTIVE_GENOME_SIZE is
+        # automatically determined.
+        macs2_param_string: 
+            value: "--broad"
 
 # Control for the postprocessing submodule
 postprocessing:

--- a/workflow/rules/coverage_and_norm.smk
+++ b/workflow/rules/coverage_and_norm.smk
@@ -15,7 +15,7 @@ rule clean_coverage_and_norm:
 
 rule run_coverage_and_norm:
     input:       
-        expand("results/coverage_and_norm/deeptools_log2ratio/{sample}_{within}_{ending}.bw",\
+        expand("results/coverage_and_norm/bwtools_compare/{sample}_{within}_{ending}.bw",\
         sample = determine_extracted_samples(pep),\
         within = WITHIN,\
         ending = ENDING)
@@ -74,7 +74,6 @@ rule deeptools_coverage:
         stderr="results/coverage_and_norm/logs/deeptools_coverage/{sample}_{norm}.err"
     params:
         resolution = RES,
-        genome_size = lambda wildcards: determine_effective_genome_size(wildcards.sample, config, pep),
         masked_regions = lambda wildcards: masked_regions_file_for_deeptools(config, wildcards.sample, pep),
         bamCoverage_param_string= lambda wildcards: lookup_in_config_persample(config,\
         pep, ["coverage_and_norm", "deeptools_coverage", "bamCoverage_param_string"], wildcards.sample,\
@@ -89,7 +88,7 @@ rule deeptools_coverage:
         "bamCoverage --bam {input.inbam} --outFileName {output} --outFileFormat 'bigwig' "
         "--numberOfProcessors {threads} --binSize {params.resolution} "
         "--normalizeUsing {wildcards.norm} "
-        "--effectiveGenomeSize {params.genome_size} "
+        "--effectiveGenomeSize $(cat {input.genome_size}) "
         "{params.masked_regions} "
         "{params.bamCoverage_param_string} "
         "> {log.stdout} 2> {log.stderr}"
@@ -133,15 +132,15 @@ rule bwtools_log2ratio:
         ext= "results/coverage_and_norm/deeptools_coverage/{sample}_{norm}.bw",
         inp= lambda wildcards: get_log2ratio_matching_input(wildcards.sample,wildcards.norm, pep)
     output:
-        "results/coverage_and_norm/deeptools_log2ratio/{sample}_{norm}_log2ratio.bw"
+        "results/coverage_and_norm/bwtools_compare/{sample}_{norm}_log2ratio.bw"
     wildcard_constraints:
         norm="RPKM|CPM|BPM|RPGC|median"
     params: 
         resolution = RES,
         dropNaNsandInfs = determine_dropNaNsandInfs(config)
     log:
-        stdout="results/coverage_and_norm/logs/bwtools_log2ratio/{sample}_{norm}_log2ratio.log",
-        stderr="results/coverage_and_norm/logs/bwtools_log2ratio/{sample}_{norm}_log2ratio.err"
+        stdout="results/coverage_and_norm/logs/bwtools_compare/{sample}_{norm}_log2ratio.log",
+        stderr="results/coverage_and_norm/logs/bwtools_compare/{sample}_{norm}_log2ratio.err"
     threads:
         1
     conda:
@@ -160,15 +159,15 @@ rule bwtools_recipratio:
         ext= "results/coverage_and_norm/deeptools_coverage/{sample}_{norm}.bw",
         inp= lambda wildcards: get_log2ratio_matching_input(wildcards.sample,wildcards.norm, pep)
     output:
-        "results/coverage_and_norm/deeptools_log2ratio/{sample}_{norm}_recipratio.bw"
+        "results/coverage_and_norm/bwtools_compare/{sample}_{norm}_recipratio.bw"
     wildcard_constraints:
         norm="RPKM|CPM|BPM|RPGC|median"
     params: 
         resolution = RES,
         dropNaNsandInfs = determine_dropNaNsandInfs(config)
     log:
-        stdout="results/coverage_and_norm/logs/bwtools_log2ratio/{sample}_{norm}_recipratio.log",
-        stderr="results/coverage_and_norm/logs/bwtools_log2ratio/{sample}_{norm}_recipratio.err"
+        stdout="results/coverage_and_norm/logs/bwtools_compare/{sample}_{norm}_recipratio.log",
+        stderr="results/coverage_and_norm/logs/bwtools_compare/{sample}_{norm}_recipratio.err"
     threads:
         1
     conda:
@@ -198,10 +197,10 @@ rule deeptools_SES_log2ratio:
         inp_ext = lambda wildcards: get_input_bai(wildcards.sample, pep)
 
     output:
-        "results/coverage_and_norm/deeptools_log2ratio/{sample}_SES_log2ratio.bw"
+        "results/coverage_and_norm/bwtools_compare/{sample}_SES_log2ratio.bw"
     log:
-        stdout="results/coverage_and_norm/logs/deeptools_log2ratio/{sample}_SES_log2ratio.log",
-        stderr="results/coverage_and_norm/logs/deeptools_log2ratio/{sample}_SES_log2ratio.err"
+        stdout="results/coverage_and_norm/logs/deeptools_compare/{sample}_SES_log2ratio.log",
+        stderr="results/coverage_and_norm/logs/deeptools_compare/{sample}_SES_log2ratio.err"
     threads:
         5
     params: 
@@ -230,8 +229,8 @@ rule bwtools_median:
         pseudocount = lambda wildcards: lookup_in_config_persample(config,\
         pep, ["coverage_and_norm", "bwtools_median", "pseudocount"], wildcards.sample, 0)
     log:
-        stdout="results/coverage_and_norm/logs/bwtools/{sample}_median.log",
-        stderr="results/coverage_and_norm/logs/bwtools/{sample}_median.err"
+        stdout="results/coverage_and_norm/logs/bwtools_manipulate/{sample}_median.log",
+        stderr="results/coverage_and_norm/logs/bwtools_manipulate/{sample}_median.err"
     conda:
         "../envs/coverage_and_norm.yaml"
     shell:
@@ -245,13 +244,13 @@ rule bwtools_median:
 
 rule bwtools_background_subtract:
     input:
-        infile = "results/coverage_and_norm/deeptools_log2ratio/{sample}_{norm}_{norm_btwn}.bw",
+        infile = "results/coverage_and_norm/bwtools_compare/{sample}_{norm}_{norm_btwn}.bw",
         background_regions = lambda wildcards: lookup_in_config_persample(config,\
         pep, ["coverage_and_norm", "bwtools_background_subtract", "background_regions"],\
         wildcards.sample,\
         "results/alignment/process_genbank/{genome}/{genome}.bed".format(genome = lookup_sample_metadata(wildcards.sample, "genome", pep)))
     output:
-        "results/coverage_and_norm/deeptools_log2ratio/{sample}_{norm}_{norm_btwn}_minbg.bw"
+        "results/coverage_and_norm/bwtools_compare/{sample}_{norm}_{norm_btwn}_minbg.bw"
     params:
         resolution = RES,
         dropNaNsandInfs = determine_dropNaNsandInfs(config)
@@ -259,8 +258,8 @@ rule bwtools_background_subtract:
         norm="RPKM|CPM|BPM|RPGC|count|SES|median",
         norm_btwn="log2ratio|recipratio|subinp"
     log:
-        stdout="results/coverage_and_norm/logs/bwtools/{sample}_{norm}_{norm_btwn}_minbg.log",
-        stderr="results/coverage_and_norm/logs/bwtools/{sample}_{norm}_{norm_btwn}_minbg.err"
+        stdout="results/coverage_and_norm/logs/bwtools_manipulate/{sample}_{norm}_{norm_btwn}_minbg.log",
+        stderr="results/coverage_and_norm/logs/bwtools_manipulate/{sample}_{norm}_{norm_btwn}_minbg.err"
     conda:
         "../envs/coverage_and_norm.yaml"
     shell:
@@ -274,15 +273,15 @@ rule bwtools_background_subtract:
 
 rule bwtools_scale_max:
     input:
-        "results/coverage_and_norm/deeptools_log2ratio/{sample}_{norm}_{norm_btwn}_minbg.bw"
+        "results/coverage_and_norm/bwtools_compare/{sample}_{norm}_{norm_btwn}_minbg.bw"
     output:
-        "results/coverage_and_norm/deeptools_log2ratio/{sample}_{norm}_{norm_btwn}_minbg_scalemax.bw"
+        "results/coverage_and_norm/bwtools_compare/{sample}_{norm}_{norm_btwn}_minbg_scalemax.bw"
     params:
         resolution = RES,
         dropNaNsandInfs = determine_dropNaNsandInfs(config)
     log:
-        stdout="results/coverage_and_norm/logs/bwtools/{sample}_{norm}_{norm_btwn}_minbg_scalemax.log",
-        stderr="results/coverage_and_norm/logs/bwtools/{sample}_{norm}_{norm_btwn}_minbg_scalemax.err"
+        stdout="results/coverage_and_norm/logs/bwtools_manipulate/{sample}_{norm}_{norm_btwn}_minbg_scalemax.log",
+        stderr="results/coverage_and_norm/logs/bwtools_manipulate/{sample}_{norm}_{norm_btwn}_minbg_scalemax.err"
     wildcard_constraints:
         norm="RPKM|CPM|BPM|RPGC|count|SES|median",
         norm_btwn="log2ratio|recipratio|subinp"
@@ -298,13 +297,13 @@ rule bwtools_scale_max:
 
 rule bwtools_query_subtract:
     input:
-        infile="results/coverage_and_norm/deeptools_log2ratio/{sample}_{norm}_{norm_btwn}.bw",
+        infile="results/coverage_and_norm/bwtools_compare/{sample}_{norm}_{norm_btwn}.bw",
         query_regions = lambda wildcards: lookup_in_config_persample(config,\
         pep, ["coverage_and_norm", "bwtools_query_subtract", "query_regions"],\
         wildcards.sample,\
         "results/alignment/process_genbank/{genome}/{genome}.bed".format(genome = lookup_sample_metadata(wildcards.sample, "genome", pep)))
     output:
-        "results/coverage_and_norm/deeptools_log2ratio/{sample}_{norm}_{norm_btwn}_querysub.bw"
+        "results/coverage_and_norm/bwtools_compare/{sample}_{norm}_{norm_btwn}_querysub.bw"
     params:
         resolution = RES,
         dropNaNsandInfs = determine_dropNaNsandInfs(config),
@@ -312,8 +311,8 @@ rule bwtools_query_subtract:
         pep, ["coverage_and_norm", "bwtools_query_subtract", "number_of_regions"],\
         wildcards.sample, 20)
     log:
-        stdout="results/coverage_and_norm/logs/bwtools/{sample}_{norm}_{norm_btwn}_querysub.log",
-        stderr="results/coverage_and_norm/logs/bwtools/{sample}_{norm}_{norm_btwn}_querysub.err"
+        stdout="results/coverage_and_norm/logs/bwtools_manipulate/{sample}_{norm}_{norm_btwn}_querysub.log",
+        stderr="results/coverage_and_norm/logs/bwtools_manipulate/{sample}_{norm}_{norm_btwn}_querysub.err"
     wildcard_constraints:
         norm="RPKM|CPM|BPM|RPGC|count|SES|median",
         norm_btwn="log2ratio|recipratio|subinp"
@@ -332,13 +331,13 @@ rule bwtools_query_subtract:
 
 rule bwtools_query_scale:
     input:
-        infile="results/coverage_and_norm/deeptools_log2ratio/{sample}_{norm}_{norm_btwn}_querysub.bw",
+        infile="results/coverage_and_norm/bwtools_compare/{sample}_{norm}_{norm_btwn}_querysub.bw",
         query_regions = lambda wildcards: lookup_in_config_persample(config,\
         pep, ["coverage_and_norm", "bwtools_query_subtract", "query_regions"],\
         wildcards.sample,\
         "results/alignment/process_genbank/{genome}/{genome}.bed".format(genome = lookup_sample_metadata(wildcards.sample, "genome", pep)))
     output:
-        "results/coverage_and_norm/deeptools_log2ratio/{sample}_{norm}_{norm_btwn}_querysub_queryscale.bw"
+        "results/coverage_and_norm/bwtools_compare/{sample}_{norm}_{norm_btwn}_querysub_queryscale.bw"
     params:
         resolution = RES,
         dropNaNsandInfs = determine_dropNaNsandInfs(config),
@@ -349,8 +348,8 @@ rule bwtools_query_scale:
         norm="RPKM|CPM|BPM|RPGC|count|SES|median",
         norm_btwn="log2ratio|recipratio|subinp"
     log:
-        stdout="results/coverage_and_norm/logs/bwtools/{sample}_{norm}_{norm_btwn}_querysub_queryscale.log",
-        stderr="results/coverage_and_norm/logs/bwtools/{sample}_{norm}_{norm_btwn}_querysub_queryscale.err"
+        stdout="results/coverage_and_norm/logs/bwtools_manipulate/{sample}_{norm}_{norm_btwn}_querysub_queryscale.log",
+        stderr="results/coverage_and_norm/logs/bwtools_manipulate/{sample}_{norm}_{norm_btwn}_querysub_queryscale.err"
     conda:
         "../envs/coverage_and_norm.yaml"
     shell:
@@ -365,12 +364,12 @@ rule bwtools_query_scale:
 
 rule bwtools_RobustZ:
     input:
-        "results/coverage_and_norm/deeptools_log2ratio/{sample}_{norm}_{norm_btwn}.bw"
+        "results/coverage_and_norm/bwtools_compare/{sample}_{norm}_{norm_btwn}.bw"
     output:
-        "results/coverage_and_norm/deeptools_log2ratio/{sample}_{norm}_{norm_btwn}RZ.bw"
+        "results/coverage_and_norm/bwtools_compare/{sample}_{norm}_{norm_btwn}RZ.bw"
     log:
-        stdout="results/coverage_and_norm/logs/bwtools/{sample}_{norm}_{norm_btwn}RZ.log",
-        stderr="results/coverage_and_norm/logs/bwtools/{sample}_{norm}_{norm_btwn}RZ.err"
+        stdout="results/coverage_and_norm/logs/bwtools_manipulate/{sample}_{norm}_{norm_btwn}RZ.log",
+        stderr="results/coverage_and_norm/logs/bwtools_manipulate/{sample}_{norm}_{norm_btwn}RZ.err"
     wildcard_constraints:
         norm="RPKM|CPM|BPM|RPGC|count|SES|median",
         norm_btwn="log2ratio|recipratio|subinp"
@@ -392,15 +391,15 @@ rule bwtools_subinp:
         ext = "results/coverage_and_norm/deeptools_coverage/{sample}_{norm}.bw",
         inp = lambda wildcards: get_log2ratio_matching_input(wildcards.sample, wildcards.norm, pep)
     output:
-        "results/coverage_and_norm/deeptools_log2ratio/{sample}_{norm}_subinp.bw"
+        "results/coverage_and_norm/bwtools_compare/{sample}_{norm}_subinp.bw"
     wildcard_constraints:
         norm = "RPKM|CPM|BPM|RPGC|median"
     params:
         resolution = RES,
         dropNaNsandInfs = determine_dropNaNsandInfs(config)
     log:
-        stdout="results/coverage_and_norm/logs/bwtools_log2ratio/{sample}_{norm}_subinp.log",
-        stderr="results/coverage_and_norm/logs/bwtools_log2ratio/{sample}_{norm}_subinp.err"
+        stdout="results/coverage_and_norm/logs/bwtools_compare/{sample}_{norm}_subinp.log",
+        stderr="results/coverage_and_norm/logs/bwtools_compare/{sample}_{norm}_subinp.err"
     threads:
         1
     conda:

--- a/workflow/rules/peak_calling.smk
+++ b/workflow/rules/peak_calling.smk
@@ -33,7 +33,7 @@ rule run_peak_calling:
 
 def determine_cmarrt_input(sample, model, config, pep):
    file_sig = lookup_in_config(config, ["peak_calling", model, "filesignature"], 
-   "results/coverage_and_norm/deeptools_log2ratio/%s_BPM_subinp.bw")
+   "results/coverage_and_norm/bwtools_compare/%s_BPM_subinp.bw")
    return file_sig%(sample)
 
 rule cmarrt_call_peaks:

--- a/workflow/rules/postprocessing.smk
+++ b/workflow/rules/postprocessing.smk
@@ -42,7 +42,7 @@ def pull_bws_for_deeptools_models(toolname, modelname, config, pep):
     these_samples = filter_samples(pep, \
     lookup_in_config(config, ["postprocessing", toolname, modelname, "filter"], "not input_sample.isnull()"))
     file_sig = lookup_in_config(config, ["postprocessing", toolname, modelname, "filesignature"],\
-    "results/coverage_and_norm/deeptools_log2ratio/%s_median_log2ratio.bw")
+    "results/coverage_and_norm/bwtools_compare/%s_median_log2ratio.bw")
     files = [file_sig%(sample) for sample in these_samples]
     return files
 

--- a/workflow/scripts/bwtools.py
+++ b/workflow/scripts/bwtools.py
@@ -307,6 +307,21 @@ def query_main(args):
     for fhandle in open_fhandles:
         fhandle.close()
 
+
+def summarize_main(args):
+
+    res = args.res
+
+    inf1 = pyBigWig.open(args.infile)
+    
+    arrays = bigwig_to_arrays(inf1, res = args.res)
+    with open(args.outfile, mode = "w") as outf:
+        outf.write("contig\tsignal\n")
+        for chrm in arrays.keys():
+            this_array = arrays[chrm]
+            the_finite = np.isfinite(this_array)
+            outf.write("%s\t%s\n"%(chrm, np.sum(this_array[the_finite])))
+
 def compare_log2ratio(arrays1, arrays2):
     out_array = {}
     for chrm in arrays1.keys():
@@ -397,6 +412,17 @@ if __name__ == "__main__":
             help = "Add value to all unmasked regions before normalization. Only\
                     applicable to the median normalization. Default = 0 ")
     parser_manipulate.set_defaults(func=manipulate_main)
+
+
+    # summarize verb
+    parser_summarize = subparsers.add_parser("summarize", help = "Get total signal per contig")
+    parser_summarize.add_argument('infile', type=str, 
+            help="file to convert from")
+    parser_summarize.add_argument('outfile', type=str, help="file to convert to")
+    parser_summarize.add_argument('--res', type=int, default=1,
+            help="Resolution to compute statistics at. Default 1bp. Note this \
+            should be set no lower than the resolution of the input file")
+    parser_summarize.set_defaults(func=summarize_main)
 
 
     # query verb


### PR DESCRIPTION
## 0.2.0 - 2021-09-08                                                               
                                                                                    
### Added                                                                           
- Support for subtracting rather than dividing the input from the extracted         
- A summarize method for `bwtools` that gives total signal per contig               
                                                                                    
### Changed                                                                         
- Refactored the config file syntax to be more general for `peak_calling`           
- Moved output of ext to inp comparisions from `results/coverage_and_norm/deeptools_log2ratio/` to `bwtools_compare/`