### PR TITLE
Add support for ratios without log transformations. Version 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Next
+## 0.2.1 - 2021-09-22
 
 ### Added
 - Support for division of the input with no log2 transformation
-- Support for subtract and scaling by a known set of regions
+- Support for subtract and scaling by a known and fixed set of regions
 
 ### Bug fixes
 - Cleaned up multiqc report config file to handle automatic sample name generation. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Next
+
+### Bug fixes
+- Cleaned up multiqc report config file to handle automatic sample name generation. 
+  Fixes issue ([#10] (https://github.com/mikewolfe/ChIPseq_pipeline/issues/10))
+
 ## 0.2.0 - 2021-09-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 - Cleaned up multiqc report config file to handle automatic sample name generation. 
-  Fixes issue ([#10] (https://github.com/mikewolfe/ChIPseq_pipeline/issues/10))
+  Fixes issue ([#10](https://github.com/mikewolfe/ChIPseq_pipeline/issues/10))
 
 ## 0.2.0 - 2021-09-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Next
 
+### Added
+- Support for division of the input with no log2 transformation
+- Support for subtract and scaling by a known set of regions
+
 ### Bug fixes
 - Cleaned up multiqc report config file to handle automatic sample name generation. 
   Fixes issue ([#10](https://github.com/mikewolfe/ChIPseq_pipeline/issues/10))

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ If you run into any issues with the pipeline and would like help please submit i
 
 # Version history
 
-Currently at version 0.2.0
+Currently at version 0.2.1
 
 See the [Changelog](CHANGELOG.md) for version history and upcoming
 features.

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -89,10 +89,17 @@ coverage_and_norm:
         # pseudocount is added before normalizing by the median
         pseudocount:
             value: 0
-    bwtools_background_subtract:
+    bwtools_fixed_subtract:
         # what regions to use as the background when doing a background
-        # subtraction
-        background_regions: 
+        # subtraction. This just uses all genes which is non-sensical.
+        # You will want to replace with what you need
+        fixed_regions: 
+            value: "results/alignment/process_genbank/U00096.3/U00096.3.bed"
+    bwtools_fixed_scale:
+        # what regions to use as the background when doing a scaling by a
+        # fixed set of regions. This just uses all genes which is also
+        # non-sensical. You will want to replace with what you need.
+        fixed_regions: 
             value: "results/alignment/process_genbank/U00096.3/U00096.3.bed"
     bwtools_query_subtract:
         # What regions to consider for a dynamically chosen background subtraction
@@ -160,7 +167,7 @@ postprocessing:
             regions: "results/alignment/process_genbank/U00096.3/U00096.3.bed"
             # which files to use? This file signature will substitute in
             # a sample name for the %s
-            filesignature: "results/coverage_and_norm/bwtools_compare/%s_median_log2ratio_querysub_queryscale.bw"
+            filesignature: "results/coverage_and_norm/bwtools_compare/%s_median_ratio_fixedsub_fixedscale.bw"
             # how many bp upstream (5') of a feature to include
             upstream: 0
             # how many bp downstream (3') of a feature to include
@@ -178,7 +185,7 @@ postprocessing:
             # which regions to use?
             regions: "results/alignment/process_genbank/U00096.3/U00096.3.bed"
             # which files to use?
-            filesignature: "results/coverage_and_norm/bwtools_compare/%s_median_log2ratio_querysub_queryscale.bw"
+            filesignature: "results/coverage_and_norm/bwtools_compare/%s_median_ratio_querysub_queryscale.bw"
             # what resolution to query data (shouldn't be lower than the
             # resolution of your file
             res : 5

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -65,10 +65,11 @@ alignment:
 
 # Options to control genome coverage calculations
 coverage_and_norm:
-    # general controls - these only control what is automatically run
-    # when running the whole pipeline or module.
+
     # what resolution in bp do you want the coverage to be calculated?
     resolution: 5
+    # general controls - these only control what is automatically run
+    # when running the whole pipeline or module.
     # how to normalize within a sample. Options include:
     # RPKM, CPM, BPM, RPGC, median, and SES. See deeptools manual for
     # details on these normalization methods.

--- a/workflow/envs/multiqc_config.yaml
+++ b/workflow/envs/multiqc_config.yaml
@@ -18,3 +18,33 @@ module_order:
 report_section_order:
     fastq_trimmed:
         before: fastqc_raw
+
+extra_fn_clean_exts:
+    - type: "truncate"
+      pattern: "bt2" 
+    - type: remove
+      pattern: "trim_paired_"
+    - type: "truncate"
+      pattern: "R1"
+      module:
+          - trimmomatic
+          - cutadapt
+    - type: "truncate"
+      pattern: "R2"
+      module:
+          - trimmomatic
+          - cutadapt
+    - type: "truncate"
+      pattern: "cutadapt"
+      module:
+          - cutadapt
+    - type: "truncate"
+      pattern: "_cut"
+      module:
+          - trimmomatic
+
+use_filename_as_sample_name:
+    - fastqc
+    - cutadapt
+
+plots_flat_numseries: 250

--- a/workflow/envs/quality_control.yaml
+++ b/workflow/envs/quality_control.yaml
@@ -4,5 +4,5 @@ channels:
 dependencies:
     - fastqc=0.11.8
     - deeptools=3.5.0
-    - multiqc=1.9.0
+    - multiqc=1.11.0
 

--- a/workflow/rules/coverage_and_norm.smk
+++ b/workflow/rules/coverage_and_norm.smk
@@ -245,10 +245,9 @@ rule bwtools_median:
 rule bwtools_fixed_subtract:
     input:
         infile = "results/coverage_and_norm/bwtools_compare/{sample}_{norm}_{norm_btwn}.bw",
-        background_regions = lambda wildcards: lookup_in_config_persample(config,\
+        fixed_regions = lambda wildcards: lookup_in_config_persample(config,\
         pep, ["coverage_and_norm", "bwtools_fixed_subtract", "fixed_regions"],\
-        wildcards.sample,\
-        "results/alignment/process_genbank/{genome}/{genome}.bed".format(genome = lookup_sample_metadata(wildcards.sample, "genome", pep)))
+        wildcards.sample)
     output:
         "results/coverage_and_norm/bwtools_compare/{sample}_{norm}_{norm_btwn}_fixedsub.bw"
     params:
@@ -267,17 +266,16 @@ rule bwtools_fixed_subtract:
        "workflow/scripts/bwtools.py manipulate "
        "{input.infile} {output} "
        "--res {params.resolution} --operation fixed_subtract "
-       "--background_regions {input.background_regions} "
+       "--fixed_regions {input.fixed_regions} "
        "{params.dropNaNsandInfs} "
        "> {log.stdout} 2> {log.stderr}"
 
 rule bwtools_fixed_scale:
     input:
         infile = "results/coverage_and_norm/bwtools_compare/{sample}_{norm}_{norm_btwn}_fixedsub.bw",
-        background_regions = lambda wildcards: lookup_in_config_persample(config,\
+        fixed_regions = lambda wildcards: lookup_in_config_persample(config,\
         pep, ["coverage_and_norm", "bwtools_fixed_scale", "fixed_regions"],\
-        wildcards.sample,\
-        "results/alignment/process_genbank/{genome}/{genome}.bed".format(genome = lookup_sample_metadata(wildcards.sample, "genome", pep)))
+        wildcards.sample)
     output:
         "results/coverage_and_norm/bwtools_compare/{sample}_{norm}_{norm_btwn}_fixedsub_fixedscale.bw"
     params:
@@ -296,7 +294,7 @@ rule bwtools_fixed_scale:
        "workflow/scripts/bwtools.py manipulate "
        "{input.infile} {output} "
        "--res {params.resolution} --operation fixed_scale "
-       "--background_regions {input.background_regions} "
+       "--fixed_regions {input.fixed_regions} "
        "{params.dropNaNsandInfs} "
        "> {log.stdout} 2> {log.stderr}"
 

--- a/workflow/scripts/bwtools.py
+++ b/workflow/scripts/bwtools.py
@@ -111,28 +111,28 @@ def Median_norm(arrays, pseudocount = 0):
         arrays[chrm] = arraytools.normalize_1D(arrays[chrm], -pseudocount, median)
     return arrays
 
-def background_subtract(arrays, background_regions = None, res = 1):
+def fixed_subtract(arrays, fixed_regions = None, res = 1):
     import bed_utils
     inbed = bed_utils.BedFile()
-    inbed.from_bed_file(background_regions)
-    background_vals = []
+    inbed.from_bed_file(fixed_regions)
+    fixed_vals = []
     for region in inbed:
-        background_vals.extend(arrays[region["chrm"]][region["start"]//res:region["end"]//res])
-    background_vals = np.array(background_vals)
-    subtract_val = np.mean(background_vals[np.isfinite(background_vals)])
+        fixed_vals.extend(arrays[region["chrm"]][region["start"]//res:region["end"]//res])
+    fixed_vals = np.array(fixed_vals)
+    subtract_val = np.mean(fixed_vals[np.isfinite(fixed_vals)])
     for chrm in arrays.keys():
         arrays[chrm] = arraytools.normalize_1D(arrays[chrm], subtract_val, 1)
     return arrays
 
-def fixed_scale(arrays, regions = None, res = 1):
+def fixed_scale(arrays, fixed_regions = None, res = 1):
     import bed_utils
     inbed = bed_utils.BedFile()
-    inbed.from_bed_file(regions)
-    vals = []
+    inbed.from_bed_file(fixed_regions)
+    fixed_vals = []
     for region in inbed:
-        vals.extend(arrays[region["chrm"]][region["start"]//res:region["end"]//res])
-    vals = np.array(background_vals)
-    scale_val = np.mean(background_vals[np.isfinite(background_vals)])
+        fixed_vals.extend(arrays[region["chrm"]][region["start"]//res:region["end"]//res])
+    fixed_vals = np.array(fixed_vals)
+    scale_val = np.mean(fixed_vals[np.isfinite(fixed_vals)])
     for chrm in arrays.keys():
         arrays[chrm] = arraytools.normalize_1D(arrays[chrm], 0, scale_val)
     return arrays
@@ -202,7 +202,7 @@ def manipulate_main(args):
 
     operation_dict={"RobustZ": RobustZ_transform, 
             "Median_norm": lambda x: Median_norm(x, args.pseudocount),
-            "fixed_subtract": lambda x: background_subtract(x, args.fixed_regions, args.res),
+            "fixed_subtract": lambda x: fixed_subtract(x, args.fixed_regions, args.res),
             "fixed_scale" : lambda x : fixed_scale(x, args.fixed_regions, args.res),
             "scale_max": lambda x: scale_max(x, 1000, args.res),
             "query_scale": lambda x: scale_region_max(x, args.number_of_regions, args.query_regions, args.res),


### PR DESCRIPTION
Closes issue #10 and issue #8 

## 0.2.1 - 2021-09-22

### Added
- Support for division of the input with no log2 transformation
- Support for subtract and scaling by a known and fixed set of regions

### Bug fixes
- Cleaned up multiqc report config file to handle automatic sample name generation. 
  Fixes issue ([#10](https://github.com/mikewolfe/ChIPseq_pipeline/issues/10))