### PR TITLE
Add variant calling rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Next
+
+### Added
+- A `variant_calling` module to call changes from the reference genome with ChIP input samples ([#2](https://github.com/mikewolfe/ChIPseq_pipeline/issues/2))
+
 ## 0.2.2 - 2021-09-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Starting from raw fastq files this pipeline does the following:
   with [`deeptools`](https://deeptools.readthedocs.io/en/latest/) and custom python scripts 
 - peak calling using either [`macs2`](https://github.com/macs3-project/MACS) or a custom python 
   implementation of [`CMARRT`](https://github.com/mikewolfe/CMARRT_python)
+- variant calling against a reference genome on ChIP input samples using
+  [`breseq`](https://barricklab.org/twiki/bin/view/Lab/ToolsBacterialGenomeResequencing)
+
 
 In addition this pipeline uses [`multiqc`](https://multiqc.info/) to compile the 
 following quality control metrics into an interactive html report:
@@ -114,6 +117,7 @@ The pipeline is organized into modules each of which runs a specific task needed
 - [workflow/rules/peak_calling.smk](workflow/rules/peak_calling.smk) includes rules for calling ChIP-seq peaks
 - [workflow/rules/quality_control.smk](workflow/rules/quality_control.smk) includes rules for performing summarizing quality control on the reads themselves and ChIP-seq specific quality control
 - [workflow/rules/postprocessing.smk](workflow/rules/postprocessing.smk) includes rules for getting summaries of ChIP signals over specified regions or locations
+- [workflow/rules/variant_calling.smk](workflow/rules/variant_calling.smk) includes rules for checking for mutations against the reference genome. Typically run on ChIP input samples. Will take awhile to run.
 
 Each of these rules can be run individually using:
 ```

--- a/Snakefile
+++ b/Snakefile
@@ -136,6 +136,7 @@ include: "workflow/rules/coverage_and_norm.smk"
 include: "workflow/rules/quality_control.smk"
 include: "workflow/rules/peak_calling.smk"
 include: "workflow/rules/postprocessing.smk"
+include: "workflow/rules/variant_calling.smk"
 
 
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -167,6 +167,14 @@ peak_calling:
         macs2_param_string: 
             value: "--broad"
 
+# Options to control variant calling. I.e. running breseq on the input samples
+variant_calling:
+    # Which samples do you want to run variant calling on. Typically
+    # only the input samples as specified by having no sample name in
+    # the "input_sample" column
+    filter: "input_sample.isnull()"
+
+
 # Control for the postprocessing submodule
 postprocessing:
     # summarizes values by region

--- a/workflow/envs/variant_calling.yaml
+++ b/workflow/envs/variant_calling.yaml
@@ -1,0 +1,7 @@
+channels:
+    - conda-forge
+    - bioconda
+dependencies:
+    - breseq=0.35.5
+    - tbb=2020.2
+    - bowtie2=2.4.2

--- a/workflow/rules/variant_calling.smk
+++ b/workflow/rules/variant_calling.smk
@@ -1,0 +1,85 @@
+def which_samples_to_run(config, pep):
+    these_samples = filter_samples(pep,
+    lookup_in_config(config, ["variant_calling", "filter"], "input_sample.isnull()"))
+    return ["results/variant_calling/breseq/%s/output/summary.html"%sample for sample in these_samples]
+
+rule run_variant_calling:
+    input:
+        which_samples_to_run(config, pep)
+
+rule clean_variant_calling:
+    shell:
+        "rm -fr results/variant_calling"
+        
+
+    
+def get_references_per_sample(sample, pep, files = "genbanks_only"):
+    '''
+    Determine which files to pass as references to breseq.
+    We want to preferentially use genbanks if possible but if
+    no genbank exists than we can add the others as fastas.
+
+    We also don't want to double add a fasta and a genbank for the
+    same reference. This is brittle code to check for that case and
+    only add fastas if they don't have a genbank file.
+
+    For now we will run things assuming you only want to run on
+    the genbanks by default
+    '''
+    genome = lookup_sample_metadata(sample, "genome", pep)
+    this_genome = lookup_in_config(config, ["reference", genome])
+    all_genbanks = []
+    all_fastas = []
+    basenames = set()
+    if "genbanks" in this_genome:
+        for key, value in this_genome["genbanks"].items():
+            all_genbanks.append(value)
+            basenames.add(key)
+    if "fastas" in this_genome:
+        for this_fasta in this_genome["fastas"]:
+            all_fastas.append(this_fasta)
+
+    # Logic to handle which reference files you want to include. For
+    # now we will leave the default to only be genbanks
+    if files == "genbanks_only":
+        all_files = all_genbanks
+    elif files == "fastas_only":
+        all_files = all_fastas
+    else:
+    # deal with the tricky case of mixing fastas and genbanks
+        all_files = all_genbanks
+        for this_fasta in all_fastas:
+            this_basename = os.path.splitext(os.path.basename(this_fasta))[0]
+            if this_basename not in basenames:
+                all_files.append(this_fasta)
+                basenames.add(this_basename)
+    return all_files
+
+def format_references_per_sample(sample, pep, files = "genbanks_only"):
+    all_files = get_references_per_sample(sample, pep, files)
+    out_str = ""
+    for this_file in all_files:
+        out_str += "-r %s "%(this_file)
+    return out_str
+
+rule breseq:
+    message: "Running breseq on {wildcards.sample}"
+    input:
+        fastq_R1 = "results/preprocessing/trimmomatic/{sample}_trim_paired_R1.fastq.gz",
+        fastq_R2 = "results/preprocessing/trimmomatic/{sample}_trim_paired_R2.fastq.gz",
+        reference_files = lambda wildcards: get_references_per_sample(wildcards.sample, pep)
+    output:
+        "results/variant_calling/breseq/{sample}/output/summary.html"
+    threads: 10
+    params:
+        reference_file_string = lambda wildcards: format_references_per_sample(wildcards.sample, pep)
+    log:
+        stdout="results/variant_calling/logs/breseq/{sample}.log",
+        stderr="results/variant_calling/logs/breseq/{sample}.err"
+    conda:
+        "../envs/variant_calling.yaml"
+    shell:
+        "breseq {params.reference_file_string} {input.fastq_R1} {input.fastq_R2} "
+        "-n {wildcards.sample} "
+        "-o results/variant_calling/breseq/{wildcards.sample} "
+        "-j {threads} > {log.stdout} 2> {log.stderr}"


### PR DESCRIPTION
This closes issue #2 

### Added
- A `variant_calling` module to call changes from the reference genome with ChIP input samples ([#2](https://github.com/mikewolfe/ChIPseq_pipeline/issues/2))