### PR TITLE
Add a summary table to variant calling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.4 - 2021-10-13
+
+### Added
+- Create a compiled html table of all mutations called across all samples in `variant_calling`
+
+### Bug fixes
+- Fixed a bug in renaming `sample/output/output.gd` files to `renamed_output/sample.gd` in `variant_calling`
+
 ## 0.2.3 - 2021-10-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ If you run into any issues with the pipeline and would like help please submit i
 
 # Version history
 
-Currently at version 0.2.2
+Currently at version 0.2.4
 
 See the [Changelog](CHANGELOG.md) for version history and upcoming
 features.


### PR DESCRIPTION
## 0.2.4 - 2021-10-13

### Added
- Create a compiled html table of all mutations called across all samples in `variant_calling`

### Bug fixes
- Fixed a bug in renaming `sample/output/output.gd` files to `renamed_output/sample.gd` in `variant_calling`