### PR TITLE
Add region-based summary calculations for RNAP ChIP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Next
+## 0.2.5 - 2021-12-08
 
-## Added
+### Added
 - Added relative polymerase progression calculation to `bwtools_query` (http://dx.doi.org/10.1016/j.molcel.2014.02.005)
 - Add the ability to smooth raw signals using convolution with a Gaussian or flat kernel. 
 - Add the ability to smooth raw signals using a Savitzky-Golay filter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add the ability to smooth raw signals using convolution with a Gaussian or flat kernel. 
 - Add the ability to smooth raw signals using a Savitzky-Golay filter
 - Ability to calculate the region-level spearman correlations for a set of samples in `bwtools_query`
+- Add calculations of the traveling ratio (10.1016/j.molcel.2008.12.021)
+- Add discovery of a local max within a region
 
 ### Changed
 - Output of `bwtools_query` is now compressed (gzip). File extension changed to `.tsv.gz`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Next
 
 ## Added
+- Added relative polymerase progression calculation to `bwtools_query` (http://dx.doi.org/10.1016/j.molcel.2014.02.005)
 - Add the ability to smooth raw signals using convolution with a Gaussian or flat kernel. 
 - Add the ability to smooth raw signals using a Savitzky-Golay filter
 - Ability to calculate the region-level spearman correlations for a set of samples in `bwtools_query`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Next
+- Add the ability to smooth raw signals using convolution with a Gaussian or flat kernel. 
+- Add the ability to smooth raw signals using a Savitzky-Golay filter
+
 ## 0.2.4 - 2021-10-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add the ability to smooth raw signals using a Savitzky-Golay filter
 - Ability to calculate the region-level spearman correlations for a set of samples in `bwtools_query`
 
+### Changed
+- Output of `bwtools_query` is now compressed (gzip). File extension changed to `.tsv.gz`
+
 ## 0.2.4 - 2021-10-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Next
+
+## Added
 - Add the ability to smooth raw signals using convolution with a Gaussian or flat kernel. 
 - Add the ability to smooth raw signals using a Savitzky-Golay filter
+- Ability to calculate the region-level spearman correlations for a set of samples in `bwtools_query`
 
 ## 0.2.4 - 2021-10-13
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ If you run into any issues with the pipeline and would like help please submit i
 # Version history
 
 
-Currently at version dev
+Currently at version 0.2.5
 
 
 See the [Changelog](CHANGELOG.md) for version history and upcoming

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ If you run into any issues with the pipeline and would like help please submit i
 # Version history
 
 
-Currently at version 0.2.4
+Currently at version dev
 
 
 See the [Changelog](CHANGELOG.md) for version history and upcoming

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -251,7 +251,7 @@ postprocessing:
             summarize: "single"
             # What single number summary do you want (mean, median, max, min)
             # only defined when summarize is "single"
-            summarize_func: "mean"
+            summary_func: "RPP"
             # what fraction of NaNs can be in a region and still report a value?
             frac_na: 0.20
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -25,7 +25,10 @@ reference:
 
 # Options to control preprocessing rules
 preprocessing:
-    # control the parameter string passed to cutadapt. Here you could change
+    # GENERAL PARADIGM FOR CONTROLLING THINGS FOR ALL SAMPLES OR SPECIFICALLY
+    # FOR EACH SAMPLE INDIVIDUALLY
+    # Example: 
+    # Control the parameter string passed to cutadapt. Here you could change
     # the adaptor sequences for every sample by using 
     # cut_param_string:
     #   value: "my string here"
@@ -35,7 +38,10 @@ preprocessing:
     # and specifying the name of the column in the
     # sample sheet that holds the strings you want to for each sample. In this
     # example it would be the column cutadapt_params that holds a string for
-    # each sample
+    # each sample.
+    #
+    # This same paradigm is used for all option that have a value or column
+    # specifier
     cutadapt_pe:
         cut_param_string:
             value: "-a AGATCGGAAGAGCACACGTCTGAACTCCAGTCA -A AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT"
@@ -81,7 +87,10 @@ coverage_and_norm:
     # Robust Z scale the log2ratio of extracted to input
     RobustZ: true
     # Which samples should be smoothed? Smoothing currently only supported for
-    # spike-in and median normalization. 
+    # spike-in and median normalization. This smooths everything.
+    # If only want inputs smoothed ('input_sample.isnull()').
+    # If want nothing smoothed ('input_sample.isnull() and not
+    # input_sample.isnull()')
     smooth_samples:
         filter: 'input_sample.isnull() or not input_sample.isnull()'
     # rule specific controls
@@ -236,8 +245,31 @@ postprocessing:
             # samples of the same type
             calc_spearman: true
         # Model 2 - look at the coverage for all genes as a mean summary
+        all_genes_mean:
+            # which regions to use?
+            regions: "results/alignment/process_genbank/U00096.3/U00096.3.bed"
+            # which files to use? Note we can use a different set than Model 1
+            filesignature: "results/coverage_and_norm/bwtools_compare/%s_median_ratio_querysub_queryscale.bw"
+            # what resolution to query data (shouldn't be lower than the
+            # resolution of your file, think of this as a sampling rate, no 
+            # averaging is done over the bins)
+            res : 5
+            # How do you want to summarize your data? (identity gives every data
+            # point in tidy format, single allows for a single number summary)
+            summarize: "single"
+            # What single number summary do you want (mean, median, max, min,
+            # etc.)
+            # only defined when summarize is "single"
+            summary_func: "mean"
+            # what fraction of NaNs can be in a region and still report a value?
+            frac_na: 0.20
+
+        # Model 3 - look at the relative polymerase progression for samples in
+        # genotype A
         genotypeA_all_genes_RPP:
-            # only consider the samples that have a genotype A
+            # only consider the samples that have a genotype A. Ensure that they
+            # have an associated input sample so that the input samples
+            # themselves are not run.
             filter: 'genotype == "A" and not input_sample.isnull()'
             # which regions to use?
             regions: "results/alignment/process_genbank/U00096.3/U00096.3.bed"
@@ -254,7 +286,8 @@ postprocessing:
             summary_func: "RPP"
             # what fraction of NaNs can be in a region and still report a value?
             frac_na: 0.20
-
+        
+        # Model 4 - look at the traveling ratio for samples in genotype A
         genotypeA_all_genes_TR:
             # only consider the samples that have a genotype A
             filter: 'genotype == "A" and not input_sample.isnull()'
@@ -262,6 +295,30 @@ postprocessing:
             regions: "results/alignment/process_genbank/U00096.3/U00096.3.bed"
             # which files to use?
             filesignature: "results/coverage_and_norm/deeptools_coverage/%s_raw.bw"
+            # Here we want to consider 300 bp upstream in our region as well
+            upstream: 300
+            # what resolution to query data (shouldn't be lower than the
+            # resolution of your file
+            res : 5
+            # How do you want to summarize your data? (identity gives every data
+            # point in tidy format, single allows for a single number summary)
+            summarize: "single"
+            # What single number summary do you want (mean, median, max, min)
+            # only defined when summarize is "single"
+            summary_func: "TR"
+            # what fraction of NaNs can be in a region and still report a value?
+            frac_na: 0.20
+
+        # Model 5 - look at the identified beta peak locations for the traveling
+        # ratio
+        genotypeA_all_genes_TR:
+            # only consider the samples that have a genotype A
+            filter: 'genotype == "A" and not input_sample.isnull()'
+            # which regions to use?
+            regions: "results/alignment/process_genbank/U00096.3/U00096.3.bed"
+            # which files to use?
+            filesignature: "results/coverage_and_norm/deeptools_coverage/%s_raw.bw"
+            # Here we want to consider 300 bp upstream in our region as well
             upstream: 300
             # what resolution to query data (shouldn't be lower than the
             # resolution of your file

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -83,13 +83,13 @@ coverage_and_norm:
     # Which samples should be smoothed? Smoothing currently only supported for
     # spike-in and median normalization. 
     smooth_samples:
-        filter: 'input_sample.isnull()'
+        filter: 'input_sample.isnull() or not input_sample.isnull()'
     # rule specific controls
     # Each of these can be specified either as a single value for every sample
     # or as a column in the sample_sheet using column: column_name
     deeptools_coverage:
         bamCoverage_param_string:
-            value: "--samFlagInclude 66 --extendReads --exactScaling --minMappingQuality 10"
+            value: "--samFlagInclude 66 --extendReads --exactScaling"
     bwtools_median:
         # pseudocount is added before normalizing by the median
         pseudocount:
@@ -126,7 +126,7 @@ coverage_and_norm:
         # coverage to use as a scaling factor. You could also use mean or
         # median over the regions considered.
         summary_func:
-            value: "sum"
+            value: "mean"
     bwtools_fixed_subtract:
         # what regions to use as the background when doing a background
         # subtraction. This just uses all genes which is non-sensical.
@@ -230,6 +230,10 @@ postprocessing:
             # How do you want to summarize your data? (identity gives every data
             # point in tidy format)
             summarize: "identity"
+            # Calculate spearman correlations between samples? Only make sense
+            # for summarize "identity". Try to do this on a small number of
+            # samples of the same type
+            calc_spearman: true
         # Model 2 - look at the coverage for all genes as a mean summary
         genotypeA_all_genes_mean:
             # only consider the samples that have a genotype A

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -97,7 +97,8 @@ coverage_and_norm:
     #Control the smoothing type and windowsize
     #Types of smoothing to specify with --operation
     #   - flat_smooth - convolution with a flat kernel (rolling mean)
-    #   - gauss_smooth - convolution with a gaussian kernel
+    #   - gauss_smooth - convolution with a gaussian kernel.
+    #       use --gauss_sigma to control the width of the gaussian.
     #   - savgol_smooth - use a Savitzky-Golay filter (see
     #                     https://en.wikipedia.org/wiki/Savitzky%E2%80%93Golay_filter)
     #For savgol, use --savgol_poly N to control the order of polynomial. A higher

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -236,7 +236,7 @@ postprocessing:
             # samples of the same type
             calc_spearman: true
         # Model 2 - look at the coverage for all genes as a mean summary
-        genotypeA_all_genes_mean:
+        genotypeA_all_genes_RPP:
             # only consider the samples that have a genotype A
             filter: 'genotype == "A" and not input_sample.isnull()'
             # which regions to use?
@@ -252,6 +252,26 @@ postprocessing:
             # What single number summary do you want (mean, median, max, min)
             # only defined when summarize is "single"
             summary_func: "RPP"
+            # what fraction of NaNs can be in a region and still report a value?
+            frac_na: 0.20
+
+        genotypeA_all_genes_TR:
+            # only consider the samples that have a genotype A
+            filter: 'genotype == "A" and not input_sample.isnull()'
+            # which regions to use?
+            regions: "results/alignment/process_genbank/U00096.3/U00096.3.bed"
+            # which files to use?
+            filesignature: "results/coverage_and_norm/deeptools_coverage/%s_raw.bw"
+            upstream: 300
+            # what resolution to query data (shouldn't be lower than the
+            # resolution of your file
+            res : 5
+            # How do you want to summarize your data? (identity gives every data
+            # point in tidy format, single allows for a single number summary)
+            summarize: "single"
+            # What single number summary do you want (mean, median, max, min)
+            # only defined when summarize is "single"
+            summary_func: "TR"
             # what fraction of NaNs can be in a region and still report a value?
             frac_na: 0.20
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -80,6 +80,10 @@ coverage_and_norm:
     dropNaNsandInfs: true
     # Robust Z scale the log2ratio of extracted to input
     RobustZ: true
+    # Which samples should be smoothed? Smoothing currently only supported for
+    # spike-in and median normalization. 
+    smooth_samples:
+        filter: 'input_sample.isnull()'
     # rule specific controls
     # Each of these can be specified either as a single value for every sample
     # or as a column in the sample_sheet using column: column_name
@@ -90,6 +94,27 @@ coverage_and_norm:
         # pseudocount is added before normalizing by the median
         pseudocount:
             value: 0
+    #Control the smoothing type and windowsize
+    #Types of smoothing to specify with --operation
+    #   - flat_smooth - convolution with a flat kernel (rolling mean)
+    #   - gauss_smooth - convolution with a gaussian kernel
+    #   - savgol_smooth - use a Savitzky-Golay filter (see
+    #                     https://en.wikipedia.org/wiki/Savitzky%E2%80%93Golay_filter)
+    #For savgol, use --savgol_poly N to control the order of polynomial. A higher
+    #value will do less smoothing. Can't be any higher than the total size of
+    #the window
+    #
+    #Other parameters:
+    # wsize - controls the size of half the window in units of resolution. Thus,
+    #         a wsize of 50 at resolution of 5 bp is a 
+    #         half window size of 50 * 5 = 250
+    #         bp. The total window size is then 250*2 + 1 = 500 bp
+    # edge - controls how to deal with the boundaries of each contig
+    #   'wrap' - wraps the array around the end. Good for circular contigs
+    #   'mirror' - mirrors half the window at the edges.
+    bwtools_smooth:
+        param_string:
+            value: "--operation 'gauss_smooth' --wsize 50 --edge 'wrap'"
     bwtools_spike_scale:
         # This controls how the spike-in regions are used to scale the
         # data when scaling to a spike-in.
@@ -194,7 +219,7 @@ postprocessing:
             regions: "results/alignment/process_genbank/U00096.3/U00096.3.bed"
             # which files to use? This file signature will substitute in
             # a sample name for the %s
-            filesignature: "results/coverage_and_norm/bwtools_compare/%s_spike_ratio_fixedsub_fixedscale.bw"
+            filesignature: "results/coverage_and_norm/bwtools_compare/%s_median_ratio.bw"
             # how many bp upstream (5') of a feature to include
             upstream: 0
             # how many bp downstream (3') of a feature to include

--- a/workflow/envs/R.yaml
+++ b/workflow/envs/R.yaml
@@ -1,0 +1,6 @@
+channels:
+    - conda-forge
+    - bioconda
+dependencies:
+    - r>=4.0
+    - r-tidyverse

--- a/workflow/rules/postprocessing.smk
+++ b/workflow/rules/postprocessing.smk
@@ -183,7 +183,7 @@ rule bwtools_query:
         "--summarize {params.summarize} "
         "--summary_func {params.summary_func} "
         "--frac_na {params.frac_na} "
-        "--gzip"
+        "--gzip "
         "> {log.stdout} 2> {log.stderr} "
 
 rule spearman_per_gene:

--- a/workflow/rules/postprocessing.smk
+++ b/workflow/rules/postprocessing.smk
@@ -28,6 +28,9 @@ def determine_postprocessing_files(config):
         outfiles.extend(
         ["results/postprocessing/bwtools_query/%s_bwtools_query.tab"%model\
         for model in config["postprocessing"]["bwtools_query"]])
+        for model in config["postprocessing"]["bwtools_query"]:
+            if config["postprocessing"]["bwtools_query"][model].get("calc_spearman", False):
+                outfiles.append("results/postprocessing/bwtools_query/"+model + "_spearman.tsv")
     return outfiles
 
 
@@ -181,3 +184,19 @@ rule bwtools_query:
         "--summary_func {params.summary_func} "
         "--frac_na {params.frac_na} "
         "> {log.stdout} 2> {log.stderr} "
+
+rule spearman_per_gene:
+    input:
+        "results/postprocessing/bwtools_query/{model}_bwtools_query.tab"
+    output:
+        "results/postprocessing/bwtools_query/{model}_spearman.tsv"
+    log:
+        stdout="results/postprocessing/logs/spearman_per_gene/{model}.log",
+        stderr = "results/postprocessing/logs/spearman_per_gene/{model}.err"
+    threads:
+        1
+    conda:
+        "../envs/R.yaml"
+    shell:
+        "Rscript workflow/scripts/region_level_spearmans.R {input} {output} > {log.stdout} "
+        "2> {log.stderr}"

--- a/workflow/rules/postprocessing.smk
+++ b/workflow/rules/postprocessing.smk
@@ -26,7 +26,7 @@ def determine_postprocessing_files(config):
 
     if lookup_in_config(config, ["postprocessing", "bwtools_query"], ""):
         outfiles.extend(
-        ["results/postprocessing/bwtools_query/%s_bwtools_query.tab"%model\
+        ["results/postprocessing/bwtools_query/%s_bwtools_query.tsv.gz"%model\
         for model in config["postprocessing"]["bwtools_query"]])
         for model in config["postprocessing"]["bwtools_query"]:
             if config["postprocessing"]["bwtools_query"][model].get("calc_spearman", False):
@@ -155,7 +155,7 @@ rule bwtools_query:
         inbws= lambda wildcards: pull_bws_for_deeptools_models("bwtools_query",wildcards.model,config, pep),
         inbed= lambda wildcards: lookup_in_config(config, ["postprocessing", "bwtools_query", wildcards.model, "regions"], None)
     output:
-        outtext="results/postprocessing/bwtools_query/{model}_bwtools_query.tab"
+        outtext="results/postprocessing/bwtools_query/{model}_bwtools_query.tsv.gz"
     log:
         stdout="results/postprocessing/logs/bwtools_query/{model}.log",
         stderr="results/postprocessing/logs/bwtools_query/{model}.err"
@@ -183,11 +183,12 @@ rule bwtools_query:
         "--summarize {params.summarize} "
         "--summary_func {params.summary_func} "
         "--frac_na {params.frac_na} "
+        "--gzip"
         "> {log.stdout} 2> {log.stderr} "
 
 rule spearman_per_gene:
     input:
-        "results/postprocessing/bwtools_query/{model}_bwtools_query.tab"
+        "results/postprocessing/bwtools_query/{model}_bwtools_query.tsv.gz"
     output:
         "results/postprocessing/bwtools_query/{model}_spearman.tsv"
     log:

--- a/workflow/scripts/arraytools.py
+++ b/workflow/scripts/arraytools.py
@@ -208,5 +208,5 @@ def traveling_ratio(array, wsize = 50, length_cutoff = 1000):
 
     center_avg = np.nanmean(array[(center - wsize):(center + wsize)])
 
-    out = peak_avg/center_avg
+    out = center_avg/peak_avg
     return out    

--- a/workflow/scripts/arraytools.py
+++ b/workflow/scripts/arraytools.py
@@ -185,4 +185,28 @@ def weighted_center(array, only_finite = True, normalize = False):
         return weighted_mean / len(array)
     else:
         return weighted_mean
+
+def relative_summit_loc(array, wsize = 50):
+    smoothed = smooth_1D(array, wsize, kernel_type = "gaussian", edge = "mirror")
+    peak = np.nanargmax(smoothed)
+    return peak
+
+def traveling_ratio(array, wsize = 50, length_cutoff = 1000):
+    # shouldn't do this with anything less than 1000 bp
+    if len(array) < length_cutoff:
+        return np.nan
+    peak = relative_summit_loc(array, wsize)
+    # peak should at the very least be in the first half of the region
+    if peak >= len(array) / 2:
+        return np.nan
+    peak_avg = np.nanmean(array[max(peak - wsize, 0):min(peak + wsize, len(array))])
     
+    # center should be far enough away that windows don't overlap
+    center = int((len(array) + peak)/2)
+    if center - wsize < peak + wsize:
+        return np.nan
+
+    center_avg = np.nanmean(array[(center - wsize):(center + wsize)])
+
+    out = peak_avg/center_avg
+    return out    

--- a/workflow/scripts/arraytools.py
+++ b/workflow/scripts/arraytools.py
@@ -164,3 +164,25 @@ def savgol_1D(array, wsize, polyorder=5, deriv=0, delta = 1.0, edge = "mirror"):
     if polyorder >= tot_size:
         raise ValueError("polyorder shouldn't be larger than window. Window %s, polyorder %s"%(tot_size, polyorder))
     return signal.savgol_filter(array, tot_size, polyorder, deriv, delta, mode = edge)
+
+def weighted_center(array, only_finite = True, normalize = False):
+    """
+    Find the weighted center of a 1D array
+
+    Args:
+        array - 1 dimensional numpy array
+        only_finite - subset the array to only include finite data points?
+        normalize - divide by 1 to give a relative center?
+    """
+    if only_finite:
+        finite = np.isfinite(array)
+    else:
+        finite = np.ones(array.shape(), dtype = "bool")
+    locs = np.arange(len(array))
+    weighted_mean = (locs[finite] * array[finite]).sum() / array[finite].sum()
+
+    if normalize:
+        return weighted_mean / len(array)
+    else:
+        return weighted_mean
+    

--- a/workflow/scripts/arraytools.py
+++ b/workflow/scripts/arraytools.py
@@ -99,3 +99,63 @@ def robustz_1D(array, ignore_nan = True):
         median = np.median(array)
     return normalize_1D(array, median, MAD)
 
+def smooth_1D(array, wsize, kernel_type = "flat", edge = "mirror"):
+    """
+    Function to smooth a 1D signal using a convolution
+
+    Args:
+        array - 1 dimensional numpy array
+        wsize - size of half the window
+        kernel - one of flat, gaussian
+        edge - one of mirror, wrap
+    Returns:
+        outarray - smoothed numpy array of same size
+    """
+    tot_size = wsize*2 + 1
+    if tot_size >= len(array):
+        raise ValueError("Window must be smaller than array. Window %s, array %s"%(tot_size, len(array)))
+
+    if kernel_type == "flat":
+        kernel = np.ones(tot_size)
+    elif kernel_type == "gaussian":
+        x = np.arange(-wsize, wsize + 1)
+        # make the weights span the kernel 
+        sigma = (wsize*2)/6
+        kernel = np.exp(- (x**2)/(2. *sigma**2))
+    else:
+        raise ValueError("kernel_type must be one of flat or gaussian. Not %s"%kernel_type)
+
+    if edge == "mirror":
+        # pad with a mirror reflection of the ends
+        s = np.r_[array[wsize:0:-1], array, array[-2:-wsize-2:-1]]
+    elif edge == "wrap":
+        # pad with a wrap around the horn
+        s = np.r_[array[(-wsize):], array, array[:wsize]]
+    else:
+        raise ValueError("edge must be one of mirror or wrap. Not %s"%edge)
+    kernel = kernel/np.sum(kernel)
+    out = np.convolve(s, kernel, mode = 'valid')
+    return out
+
+def savgol_1D(array, wsize, polyorder=5, deriv=0, delta = 1.0, edge = "mirror"):
+    """
+    Function to smooth a 1D signal using a Savitzky-Golay filter
+
+    Args:
+        array - 1 dimensional numpy array
+        wsize - size of half the window
+        edge - one of mirror, wrap, nearest, constant
+    Returns:
+        outarray - smoothed numpy array of same size
+
+    See also:
+        https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.savgol_filter.html
+    """
+    from scipy import signal
+    tot_size = wsize*2 + 1
+
+    if tot_size >= len(array):
+        raise ValueError("Window must be smaller than array. Window %s, array %s"%(tot_size, len(array)))
+    if polyorder >= tot_size:
+        raise ValueError("polyorder shouldn't be larger than window. Window %s, polyorder %s"%(tot_size, polyorder))
+    return signal.savgol_filter(array, tot_size, polyorder, deriv, delta, mode = edge)

--- a/workflow/scripts/arraytools.py
+++ b/workflow/scripts/arraytools.py
@@ -99,7 +99,7 @@ def robustz_1D(array, ignore_nan = True):
         median = np.median(array)
     return normalize_1D(array, median, MAD)
 
-def smooth_1D(array, wsize, kernel_type = "flat", edge = "mirror"):
+def smooth_1D(array, wsize, kernel_type = "flat", edge = "mirror", sigma = None):
     """
     Function to smooth a 1D signal using a convolution
 
@@ -108,19 +108,24 @@ def smooth_1D(array, wsize, kernel_type = "flat", edge = "mirror"):
         wsize - size of half the window
         kernel - one of flat, gaussian
         edge - one of mirror, wrap
+        sigma - width of the gaussian in standard deviations. Default is (wsize*2)/6
     Returns:
         outarray - smoothed numpy array of same size
     """
     tot_size = wsize*2 + 1
     if tot_size >= len(array):
-        raise ValueError("Window must be smaller than array. Window %s, array %s"%(tot_size, len(array)))
+        old_wsize = wsize
+        wsize = (len(array) - 1)//2
+        tot_size = wsize*2 + 1
+        logging.warning("Window is larger than array. Truncating window to size of array from: %s to: %s"%(old_wsize, wsize))
 
     if kernel_type == "flat":
         kernel = np.ones(tot_size)
     elif kernel_type == "gaussian":
         x = np.arange(-wsize, wsize + 1)
         # make the weights span the kernel 
-        sigma = (wsize*2)/6
+        if sigma is None:
+            sigma = (wsize*2)/6
         kernel = np.exp(- (x**2)/(2. *sigma**2))
     else:
         raise ValueError("kernel_type must be one of flat or gaussian. Not %s"%kernel_type)

--- a/workflow/scripts/bwtools.py
+++ b/workflow/scripts/bwtools.py
@@ -557,8 +557,8 @@ if __name__ == "__main__":
     parser_query.add_argument('--frac_na', type = float, help = "When reporting summaries for regions, how much of the region\
             can be NA before reporting the value as NA? default = 0.25", default = 0.25)
     parser_query.add_argument('--summary_func', type = str, help = "What function to use to summarize data when not using \
-            'identity' summary. mean, median, max, min supported. Additionally, traveling ratio (TR) and relative polymerase progression (RP) are \
-            supported. Default = 'mean'", default = "mean")
+            'identity' summary. mean, median, max, min supported. Additionally, traveling ratio ('TR') and relative polymerase progression ('RPP'), \
+            and 'summit_loc' (local peak identification) are supported. Default = 'mean'", default = "mean")
     parser_query.add_argument('--gzip', action = "store_true", help = "gzips the output if flag is included")
     parser_query.set_defaults(func=query_main)
 

--- a/workflow/scripts/bwtools.py
+++ b/workflow/scripts/bwtools.py
@@ -314,6 +314,13 @@ def query_summarize_identity(all_bws, samp_names, samp_to_fname, inbed, res, gzi
 def relative_polymerase_progression(array):
     return arraytools.weighted_center(array, only_finite = True, normalize = True) 
 
+def traveling_ratio(array, res, wsize, maxsize):
+    return arraytools.traveling_ratio(array, wsize = wsize//res, length_cutoff = maxsize//res)
+
+def summit_loc(array, res, wsize, upstream):
+    loc = arraytools.relative_summit_loc(array, wsize = wsize//res)
+    return loc*res - upstream
+
 def query_summarize_single(all_bws, samp_names, samp_to_fname, inbed, res, summary_func = np.nanmean, frac_na = 0.25, gzip = False):
     outvalues = {fname: [] for fname in args.infiles}
     region_names = []
@@ -378,7 +385,9 @@ def query_main(args):
             'median': np.nanmedian,
             'max' : np.nanmax,
             'min' : np.nanmin,
-            'RPP' : relative_polymerase_progression}
+            'RPP' : relative_polymerase_progression,
+            'TR' : lambda array: traveling_ratio(array, args.res, 50, 1000),
+            'summit_loc': lambda array: summit_loc(array, args.res, 50, args.upstream)}
     try:
         summary_func = summary_funcs[args.summary_func]
     except KeyError:
@@ -548,7 +557,8 @@ if __name__ == "__main__":
     parser_query.add_argument('--frac_na', type = float, help = "When reporting summaries for regions, how much of the region\
             can be NA before reporting the value as NA? default = 0.25", default = 0.25)
     parser_query.add_argument('--summary_func', type = str, help = "What function to use to summarize data when not using \
-            'identity' summary. mean, median, max, min supported. Default = 'mean'", default = "mean")
+            'identity' summary. mean, median, max, min supported. Additionally, traveling ratio (TR) and relative polymerase progression (RP) are \
+            supported. Default = 'mean'", default = "mean")
     parser_query.add_argument('--gzip', action = "store_true", help = "gzips the output if flag is included")
     parser_query.set_defaults(func=query_main)
 

--- a/workflow/scripts/bwtools.py
+++ b/workflow/scripts/bwtools.py
@@ -111,7 +111,7 @@ def Median_norm(arrays, pseudocount = 0):
         arrays[chrm] = arraytools.normalize_1D(arrays[chrm], -pseudocount, median)
     return arrays
 
-def smooth(arrays, wsize, kernel_type, edge):
+def smooth(arrays, wsize, kernel_type, edge, sigma = None):
     """
     Smooth data using a convolution with a kernel (flat or gaussian).
 
@@ -125,7 +125,7 @@ def smooth(arrays, wsize, kernel_type, edge):
         outarrays - dictionary of numpy arrays
     """
     for chrm in arrays.keys():
-        arrays[chrm] = arraytools.smooth_1D(arrays[chrm], wsize, kernel_type, edge)
+        arrays[chrm] = arraytools.smooth_1D(arrays[chrm], wsize, kernel_type, edge, sigma)
     return arrays
 
 def savgol(arrays, wsize, polyorder, edge):
@@ -249,7 +249,7 @@ def manipulate_main(args):
             "query_scale": lambda x: scale_region_max(x, args.number_of_regions, args.query_regions, args.res, summary_func = summary_func_dict[args.summary_func]),
             "query_subtract": lambda x: query_subtract(x, args.res, args.query_regions, args.number_of_regions, summary_func = summary_func_dict[args.summary_func]),
             "spike_scale": lambda x: fixed_scale(x, args.fixed_regions, args.res, summary_func = summary_func_dict[args.summary_func]),
-            "gauss_smooth": lambda x: smooth(x, args.wsize, kernel_type = "gaussian", edge = args.edge),
+            "gauss_smooth": lambda x: smooth(x, args.wsize, kernel_type = "gaussian", edge = args.edge, sigma = args.gauss_sigma),
             "flat_smooth": lambda x: smooth(x, args.wsize, kernel_type = "flat", edge = args.edge),
             "savgol_smooth": lambda x: savgol(x, args.wsize, polyorder = args.savgol_poly, edge = args.edge)}
 
@@ -489,6 +489,9 @@ if __name__ == "__main__":
     parser_manipulate.add_argument('--savgol_poly', type = int,
             help = "For Savtizky-Golay smoothing what order polynomial? Must not \
             be larger than the full window size.")
+    parser_manipulate.add_argument('--gauss_sigma', type = int,
+            help = "For gaussian smoothing what is sigma? Must not \
+            be larger than the full window size. Default is wsize*2/6")
     parser_manipulate.set_defaults(func=manipulate_main)
 
 

--- a/workflow/scripts/bwtools.py
+++ b/workflow/scripts/bwtools.py
@@ -311,6 +311,9 @@ def query_summarize_identity(all_bws, samp_names, samp_to_fname, inbed, res, gzi
                 line = "%s\t%s\t%s\n"%(region, coord, values_func(i))
                 outf.write(line)
 
+def relative_polymerase_progression(array):
+    return arraytools.weighted_center(array, only_finite = True, normalize = True) 
+
 def query_summarize_single(all_bws, samp_names, samp_to_fname, inbed, res, summary_func = np.nanmean, frac_na = 0.25, gzip = False):
     outvalues = {fname: [] for fname in args.infiles}
     region_names = []
@@ -328,7 +331,10 @@ def query_summarize_single(all_bws, samp_names, samp_to_fname, inbed, res, summa
             these_values = these_arrays[region["chrm"]][left_coord//res:right_coord//res]
             # add a filter for regions that have high amounts of nans
             if (np.sum(np.isnan(these_values)) / len(these_values)) < frac_na:
-                this_summary = summary_func(these_values)
+                if region["strand"] == "-":
+                    this_summary = summary_func(these_values[::-1])
+                else:
+                    this_summary = summary_func(these_values)
             else:
                 this_summary = np.nan
             outvalues[fname].append(this_summary)
@@ -371,7 +377,8 @@ def query_main(args):
     summary_funcs = {'mean' : np.nanmean,
             'median': np.nanmedian,
             'max' : np.nanmax,
-            'min' : np.nanmin}
+            'min' : np.nanmin,
+            'RPP' : relative_polymerase_progression}
     try:
         summary_func = summary_funcs[args.summary_func]
     except KeyError:

--- a/workflow/scripts/region_level_spearmans.R
+++ b/workflow/scripts/region_level_spearmans.R
@@ -1,0 +1,41 @@
+#' load in required libraries
+suppressMessages(library(tidyverse))
+
+# Check for correspondance between biological replicates across a set of
+# regions
+
+spearman_per_region <- function(d){
+    samples <- colnames(d %>% select(-c(region,coord)))
+    out <- list()
+    k <- 1
+    # do every combination of samples only once
+    for(i in seq_along(samples)){
+        for(j in seq_along(samples)){
+            # skip the upper diagonal
+            if(j <= i){
+                next
+            }
+            # use syntax to get past tidy_eval issues
+            samp1 <- samples[[i]]
+            samp2 <- samples[[j]]
+            out[[k]] <- d %>% group_by(region) %>%
+                    summarize(cor = cor(!!sym(samp1), !!sym(samp2), method = "sp"),
+                              samp1 = samples[[i]],
+                              samp2 = samples[[j]],
+                              avg_samp1 = mean(!!sym(samp1), na.rm = TRUE),
+                              avg_samp2 = mean(!!sym(samp2), na.rm = TRUE))
+        # increment our combo counter
+        k <- k + 1
+        }
+    }
+    # bind into one dataframe
+    bind_rows(out)
+} 
+
+args <- commandArgs(trailingOnly = TRUE)
+
+ind <- read_tsv(args[1])
+
+out <- spearman_per_region(ind)
+
+write_tsv(out, args[2])


### PR DESCRIPTION
### Added
- Added relative polymerase progression calculation to `bwtools_query` (http://dx.doi.org/10.1016/j.molcel.2014.02.005)
- Add the ability to smooth raw signals using convolution with a Gaussian or flat kernel. 
- Add the ability to smooth raw signals using a Savitzky-Golay filter
- Ability to calculate the region-level spearman correlations for a set of samples in `bwtools_query`
- Add calculations of the traveling ratio (10.1016/j.molcel.2008.12.021)
- Add discovery of a local max within a region

### Changed
- Output of `bwtools_query` is now compressed (gzip). File extension changed to `.tsv.gz`