### PR TITLE
Add motif calling and update peak calling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add a motif calling module. Supports both `meme` and `streme` motif callers
 - Added fimo calling with discovered motifs
+- Add ability get coverage around the set of peaks for each sample
 - Combine bed files from each chromosome into one master bed file
 - Create an annotation file that maps unique name to locust tags and gene names
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,26 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Develop
+## 0.2.9 - 2022-05-26
 
 ### Added
 - Add a motif calling module. Supports both `meme` and `streme` motif callers
 - Added fimo calling with discovered motifs
 - Add ability get coverage around the set of peaks for each sample
 - Combine bed files from each chromosome into one master bed file
-- Create an annotation file that maps unique name to locust tags and gene names
+- Create an annotation file that maps unique name to locus tags and gene names
 
 ### Changed
 - Split macs2 broad and macs2 default into their own peak callers. Always call
   summits when running macs2 without broad specified
 
-## 0.2.8 - 2021-01-20
+## 0.2.8 - 2022-01-20
 
 ### Added
 - Ability to collapse multiple bigwig files into one using summary stats
 - Ability to perform operations between two groups of bigwig files
 
-## 0.2.7 - 2021-01-10
+## 0.2.7 - 2022-01-10
 
 ### Added
 - Added support for single end libraries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Develop
+- Split macs2 broad and macs2 default into their own peak callers. Always call
+  summits when running macs2 without broad specified
+- Start on adding in motif calling
+
 ## 0.2.8 - 2021-01-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Develop
+
+### Added
+- Add a motif calling module. Supports both `meme` and `streme` motif callers
+
+### Changed
 - Split macs2 broad and macs2 default into their own peak callers. Always call
   summits when running macs2 without broad specified
-- Start on adding in motif calling
 
 ## 0.2.8 - 2021-01-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add a motif calling module. Supports both `meme` and `streme` motif callers
+- Added fimo calling with discovered motifs
 - Combine bed files from each chromosome into one master bed file
 - Create an annotation file that maps unique name to locust tags and gene names
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add a motif calling module. Supports both `meme` and `streme` motif callers
+- Combine bed files from each chromosome into one master bed file
+- Create an annotation file that maps unique name to locust tags and gene names
 
 ### Changed
 - Split macs2 broad and macs2 default into their own peak callers. Always call

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ The pipeline is organized into modules each of which runs a specific task needed
 - [workflow/rules/alignment.smk](workflow/rules/alignment.smk) includes rules for aligning samples to their reference genome
 - [workflow/rules/coverage_and_norm.smk](workflow/rules/coverage_and_norm.smk) includes rules for calculating read coverage over the genome and performing within and between sample normalization
 - [workflow/rules/peak_calling.smk](workflow/rules/peak_calling.smk) includes rules for calling ChIP-seq peaks
+- [workflow/rules/motif_calling.smk](workflow/rules/motif_calling.smk) includes rules for calling motifs in ChIP-seq peaks
 - [workflow/rules/quality_control.smk](workflow/rules/quality_control.smk) includes rules for performing summarizing quality control on the reads themselves and ChIP-seq specific quality control
 - [workflow/rules/postprocessing.smk](workflow/rules/postprocessing.smk) includes rules for getting summaries of ChIP signals over specified regions or locations
 - [workflow/rules/variant_calling.smk](workflow/rules/variant_calling.smk) includes rules for checking for mutations against the reference genome. Typically run on ChIP input samples. Will take awhile to run.
@@ -148,7 +149,7 @@ If you run into any issues with the pipeline and would like help please submit i
 # Version history
 
 
-Currently at version 0.2.8
+Currently at version 0.2.9
 
 
 See the [Changelog](CHANGELOG.md) for version history and upcoming

--- a/Snakefile
+++ b/Snakefile
@@ -159,6 +159,7 @@ include: "workflow/rules/quality_control.smk"
 include: "workflow/rules/peak_calling.smk"
 include: "workflow/rules/postprocessing.smk"
 include: "workflow/rules/variant_calling.smk"
+include: "workflow/rules/motif_calling.smk"
 
 
 

--- a/Snakefile
+++ b/Snakefile
@@ -74,7 +74,7 @@ def lookup_in_config_persample(config, pep, keys, sample, default = None, err = 
         else:
             logger.info("No value or column specifier found for keys: '%s' in config file. Defaulting to %s"%(", ".join(keys), default))
             outval = default
-    elif default:
+    elif default is not None:
         logger.info("No value or column specifier found for keys: '%s' in config file. Defaulting to %s"%(", ".join(keys), default))
         outval = default 
     else:
@@ -82,6 +82,7 @@ def lookup_in_config_persample(config, pep, keys, sample, default = None, err = 
             logger.error(err)
         else:
             logger.error("No value or column specifier found for keys: '%s' in config file. No default"%(", ".join(keys)))
+            raise ValueError
     return outval
             
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -254,9 +254,31 @@ peak_calling:
 
         # specify a parameter string used to control macs2
         # -g EFFECTIVE_GENOME_SIZE is
-        # automatically determined.
+        # automatically determined --call-summits is always specified.
         macs2_param_string: 
             column: macs2_params
+
+    macs2_broad_all:
+        peak_caller: "macs2_broad"
+        # filter out the samples you want to run based on metadata
+        filter: 'not input_sample.isnull()'
+        # Macs2 runs directly on the bam files for each sample so
+        # a filesignature does not need to specified.
+
+        # specify a parameter string used to control macs2
+        # -g EFFECTIVE_GENOME_SIZE is
+        # automatically determined --call-summits is always specified.
+        macs2_param_string: 
+            column: macs2_params
+
+# Options to control motif calling
+motif_calling:
+    macs2_all:
+        motif_caller: "streme"
+        filter: 'not input_sample.isnull()'
+        filesignature: "results/peak_calling/macs2_all/macs2/%s_summits.bed"
+        streme_param_string:
+            value: 
 
 # Options to control variant calling. I.e. running breseq on the input samples
 variant_calling:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -317,7 +317,7 @@ postprocessing:
             # which regions to use? Specifying a file like this has the pipeline
             # parse it from your genbank file given the process genbank
             # parameters above in the alignment section
-            regions: "results/alignment/process_genbank/U00096.3/U00096.3.bed"
+            regions: "results/alignment/combine_bed/U00096.3/U00096.3.bed"
             # which files to use? This file signature will substitute in
             # a sample name for the %s
             filesignature: "results/coverage_and_norm/bwtools_compare/%s_median_ratio.bw"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -225,7 +225,9 @@ quality_control:
     # what column to group samples by for ChIP-QC output plots?
     group_by: genome
 
+
 # Options to control peak calling
+# run with run_peak_calling
 peak_calling:
     # Can make different models to try out different peak callers or parameters
     cmarrt_all:
@@ -280,26 +282,35 @@ peak_calling:
             column: macs2_params
 
 # Options to control motif calling
+# run with run_motif_calling
 motif_calling:
+    # Can make different models to try out different motif callers or params
     macs2_all:
+        # Which motif caller? Supports meme and streme
         motif_caller: "streme"
+        # Which samples to run on?
         filter: 'not input_sample.isnull()'
+        # Which file to run on?
         filesignature: "results/peak_calling/macs2_all/macs2/%s_summits.bed"
+        # Parameters for the background markov model
         get_markov_param_string:
             value: "-dna -m 2"
+        # Parameters for the streme motif caller
         streme_param_string:
             value: "--dna --minw 8 --maxw 30 --nmotifs 2"
+        # Parameters controlling how the sequences are pulled from the bed
         get_peak_seqs_param_string:
             value: "--upstream 30 --downstream 30"
 
-#    macs2_all_meme:
-#        motif_caller: "meme"
-#        filter: 'not input_sample.isnull()'
-#        filesignature: "results/peak_calling/macs2_all/macs2/%s_summits.bed"
-#        get_markov_param_string:
-#            value: "-dna -m 0"
-#        get_peak_seqs_param_string:
-#            value: "--upstream 30 --downstream 30"
+    # Same thing but running a different motif finder
+    macs2_all_meme:
+        motif_caller: "meme"
+        filter: 'not input_sample.isnull()'
+        filesignature: "results/peak_calling/macs2_all/macs2/%s_summits.bed"
+        get_markov_param_string:
+            value: "-dna -m 0"
+        get_peak_seqs_param_string:
+            value: "--upstream 30 --downstream 30"
 
 # Options to control variant calling. I.e. running breseq on the input samples
 variant_calling:
@@ -430,4 +441,3 @@ postprocessing:
             summary_func: "TR"
             # what fraction of NaNs can be in a region and still report a value?
             frac_na: 0.20
-

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -277,8 +277,21 @@ motif_calling:
         motif_caller: "streme"
         filter: 'not input_sample.isnull()'
         filesignature: "results/peak_calling/macs2_all/macs2/%s_summits.bed"
+        get_markov_param_string:
+            value: "-dna -m 2"
         streme_param_string:
-            value: 
+            value: "--dna --minw 8 --maxw 30 --nmotifs 2"
+        get_peak_seqs_param_string:
+            value: "--upstream 30 --downstream 30"
+
+#    macs2_all_meme:
+#        motif_caller: "meme"
+#        filter: 'not input_sample.isnull()'
+#        filesignature: "results/peak_calling/macs2_all/macs2/%s_summits.bed"
+#        get_markov_param_string:
+#            value: "-dna -m 0"
+#        get_peak_seqs_param_string:
+#            value: "--upstream 30 --downstream 30"
 
 # Options to control variant calling. I.e. running breseq on the input samples
 variant_calling:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -257,6 +257,14 @@ peak_calling:
         # automatically determined --call-summits is always specified.
         macs2_param_string: 
             column: macs2_params
+        peak_coverage:
+            cov_filesig: 
+                value: "results/coverage_and_norm/deeptools_coverage/%s_raw.bw"
+            peaks_filesig: 
+                value: "results/peak_calling/macs2_all/macs2/%s_peaks.narrowPeak"
+            upstream: 200
+            downstream: 200
+
 
     macs2_broad_all:
         peak_caller: "macs2_broad"

--- a/pep/test_samples.csv
+++ b/pep/test_samples.csv
@@ -1,10 +1,10 @@
 sample_name,filenameR1,filenameR2,file_path,input_sample,genotype,genome,bamCoverage_params,macs2_params
-genotypeA_rep1_ext,genotypeA_rep1_ext_R1.fastq.gz,genotypeA_rep1_ext_R2.fastq.gz,source1,genotypeA_rep1_inp,A,U00096.3,--samFlagInclude 67 --extendReads,-f BAMPE --broad
-genotypeA_rep2_ext,genotypeA_rep2_ext_R1.fastq.gz,genotypeA_rep2_ext_R2.fastq.gz,source1,genotypeA_rep2_inp,A,U00096.3,--samFlagInclude 67 --extendReads,-f BAMPE --broad
+genotypeA_rep1_ext,genotypeA_rep1_ext_R1.fastq.gz,genotypeA_rep1_ext_R2.fastq.gz,source1,genotypeA_rep1_inp,A,U00096.3,--samFlagInclude 67 --extendReads,-f BAMPE
+genotypeA_rep2_ext,genotypeA_rep2_ext_R1.fastq.gz,genotypeA_rep2_ext_R2.fastq.gz,source1,genotypeA_rep2_inp,A,U00096.3,--samFlagInclude 67 --extendReads,-f BAMPE
 genotypeA_rep1_inp,genotypeA_rep1_inp_R1.fastq.gz,genotypeA_rep1_inp_R2.fastq.gz,source1,,A,U00096.3,--samFlagInclude 67 --extendReads,
 genotypeA_rep2_inp,genotypeA_rep2_inp_R1.fastq.gz,genotypeA_rep2_inp_R2.fastq.gz,source1,,A,U00096.3,--samFlagInclude 67 --extendReads,
-genotypeB_rep1_ext,genotypeB_rep1_ext_R1.fastq.gz,genotypeB_rep1_ext_R2.fastq.gz,source1,genotypeB_rep1_inp,B,U00096.3,--samFlagInclude 67 --extendReads,-f BAMPE --broad
-genotypeB_rep2_ext,genotypeB_rep2_ext_R1.fastq.gz,genotypeB_rep2_ext_R2.fastq.gz,source1,genotypeB_rep2_inp,B,U00096.3,--samFlagInclude 67 --extendReads,-f BAMPE --broad
+genotypeB_rep1_ext,genotypeB_rep1_ext_R1.fastq.gz,genotypeB_rep1_ext_R2.fastq.gz,source1,genotypeB_rep1_inp,B,U00096.3,--samFlagInclude 67 --extendReads,-f BAMPE
+genotypeB_rep2_ext,genotypeB_rep2_ext_R1.fastq.gz,genotypeB_rep2_ext_R2.fastq.gz,source1,genotypeB_rep2_inp,B,U00096.3,--samFlagInclude 67 --extendReads,-f BAMPE
 genotypeB_rep1_inp,genotypeB_rep1_inp_R1.fastq.gz,genotypeB_rep1_inp_R2.fastq.gz,source1,,B,U00096.3,--samFlagInclude 67 --extendReads,
 genotypeB_rep2_inp,genotypeB_rep2_inp_R1.fastq.gz,genotypeB_rep2_inp_R2.fastq.gz,source1,,B,U00096.3,--samFlagInclude 67 --extendReads,
-genotypeA_rep2_ext_se,genotypeA_rep2_ext_R1.fastq.gz,,source1,genotypeA_rep2_inp,A,U00096.3," ",-f BAM --broad
+genotypeA_rep2_ext_se,genotypeA_rep2_ext_R1.fastq.gz,,source1,genotypeA_rep2_inp,A,U00096.3," ",-f BAM

--- a/workflow/envs/motif_calling.yaml
+++ b/workflow/envs/motif_calling.yaml
@@ -1,0 +1,5 @@
+channels:
+    - conda-forge
+    - bioconda
+dependencies:
+    - meme

--- a/workflow/rules/alignment.smk
+++ b/workflow/rules/alignment.smk
@@ -15,6 +15,12 @@ rule run_alignment:
 def get_genome_fastas(config, genome):
     return config["reference"][genome]["fastas"]
 
+def get_genome_annotations(config, genome, ext = "bed"):
+    out = []
+    for key in lookup_in_config(config, ["reference", genome, "genbanks"]).keys():
+       out.append("results/alignment/process_genbank/%s/%s.%s"%(genome, key, ext))
+    return out
+
 def get_bt2_index(sample, pep):
     reference = lookup_sample_metadata(sample, "genome", pep)
     return "results/alignment/bowtie2_index/%s/%s"%(reference,reference)
@@ -94,6 +100,38 @@ rule combine_fastas:
          "results/alignment/combine_fasta/{wildcards.genome}/{wildcards.genome} "
          "{params.masked_regions} "
          "{input} > {log.stdout} 2> {log.stderr}"
+
+rule combine_beds:
+    message: "Generating bed for genome {wildcards.genome}"
+    input:
+        lambda wildcards: get_genome_annotations(config, wildcards.genome, ext = "bed")
+    output:
+        "results/alignment/combine_bed/{genome}/{genome}.bed",
+    log:
+        stdout="results/alignment/logs/combine_bed/{genome}/{genome}.log",
+        stderr="results/alignment/logs/combine_bed/{genome}/{genome}.err"
+    threads: 1
+    conda:
+        "../envs/alignment.yaml"
+    shell:
+         "python3 workflow/scripts/combine_bed.py "
+         "results/alignment/combine_bed/{wildcards.genome}/{wildcards.genome} "
+         "{input} > {log.stdout} 2> {log.stderr}"
+
+rule get_annotation_table:
+    input:
+        lambda wildcards: get_genome_annotations(config, wildcards.genome, ext = "tsv")
+    output:
+        "results/alignment/combine_bed/{genome}/{genome}_annotations.tsv",
+    log:
+        stdout="results/alignment/logs/get_annotation_table/{genome}/{genome}.log",
+        stderr="results/alignment/logs/get_annotation_table/{genome}/{genome}.err"
+    threads: 1
+    run:
+        shell("cat %s > {output}"%(input[0]))
+        if len(input) > 1:
+            for inf in input[1:]:
+                shell("cat %s | tail -n +2 >> {output}"%(inf)) 
     
 rule bowtie2_index:
     input:

--- a/workflow/rules/motif_calling.smk
+++ b/workflow/rules/motif_calling.smk
@@ -20,10 +20,10 @@ def determine_motif_calling_files(config, pep):
         lookup_in_config(config, ["motif_calling", model, "filter"], "not input_sample.isnull()"))
         if motif_caller == "streme":
             for sample in these_samples:
-                outfiles.append("results/motif_calling/%s/streme/%s/streme.txt"%(model, sample))
+                outfiles.append("results/motif_calling/%s/streme/renamed_output/%s.txt"%(model, sample))
         if motif_caller == "meme":
             for sample in these_samples:
-                outfiles.append("results/motif_calling/%s/meme/%s/meme.txt"%(model,sample))
+                outfiles.append("results/motif_calling/%s/meme/renamed_output/%s.txt"%(model,sample))
     return outfiles
 
 rule run_motif_calling:
@@ -104,6 +104,18 @@ rule streme_call_motifs:
         "> {log.stdout} 2> {log.stderr}"
 
 
+rule rename_streme_output:
+    input:
+        motifs="results/motif_calling/{model}/streme/{sample}/streme.txt",
+        seqs= "results/motif_calling/{model}/streme/{sample}/sequences.tsv"
+    output:
+        outmotifs="results/motif_calling/{model}/streme/renamed_output/{sample}.txt",
+        outseqs="results/motif_calling/{model}/streme/renamed_output/{sample}.tsv"
+
+    threads: 1
+    shell:
+        "cp {input.motifs} {output.outmotifs} && cp {input.seqs} {output.outseqs}"
+
 rule meme_call_motifs:
     input:
         inseqs = "results/motif_calling/{model}/get_peak_seqs/{sample}_peak_seqs.fa",
@@ -127,3 +139,12 @@ rule meme_call_motifs:
         "-bfile {input.bg} "
         "{params.meme_param_string} "
         "> {log.stdout} 2> {log.stderr}"
+
+rule rename_meme_output:
+    input:
+        motifs="results/motif_calling/{model}/meme/{sample}/meme.txt"
+    output:
+        outmotifs="results/motif_calling/{model}/meme/renamed_output/{sample}.txt"
+    threads: 1
+    shell:
+        "cp {input.motifs} {output.outmotifs} "

--- a/workflow/rules/motif_calling.smk
+++ b/workflow/rules/motif_calling.smk
@@ -1,0 +1,78 @@
+## HELPER FUNCTIONS inherited from parent SnakeFile:
+# samples(pep)
+# lookup_sample_metadata(sample, key, pep)
+
+# GLOBAL CONSTANTS inherited from parent Snakefile:
+# RES - resolution of coverage
+# WITHIN - normalization to perform within samples
+ 
+rule clean_motif_calling:
+    shell:
+        "rm -fr results/motif_calling"
+
+
+def determine_motif_calling_files(config, pep):
+    outfiles = []
+    for model in lookup_in_config(config, ["motif_calling"], []):
+        motif_caller = lookup_in_config(config, ["motif_calling", model, "motif_caller"], 
+        err = "Need motif caller specified for motif_caller model %s in config file. I.e. \nmotif_calling:\n\t%s:\n\t\tmotif_caller: 'macs2'"%(model,model))
+        these_samples = filter_samples(pep, \
+        lookup_in_config(config, ["motif_calling", model, "filter"], "not input_sample.isnull()"))
+        if motif_caller == "streme":
+            for sample in these_samples:
+                outfiles.append("results/motif_calling/%s/streme/%s/streme.txt"%(model, sample))
+        if motif_caller == "meme":
+            for sample in these_samples:
+                outfiles.append("results/motif_calling/%s/meme/%s/meme.txt"%(model,sample))
+    return outfiles
+
+rule run_motif_calling:
+    input:
+        determine_motif_calling_files(config, pep)
+
+
+def determine_filesig_input(sample, model, config, pep):
+   file_sig = lookup_in_config(config, ["peak_calling", model, "filesignature"])
+   return file_sig%(sample)
+
+rule get_peak_seqs:
+    input: 
+        lambda wildcards: determine_seq_input(wildcards.sample, wildcards.model, config, pep)
+    output:
+        "results/motif_calling/{model}/get_peak_seqs/{sample}_peak_seqs.fa"
+    log:
+        stdout="results/motif_calling/logs/{model}/get_peak_seqs/{sample}.log",
+        stderr="results/motif_calling/logs/{model}/get_peak_seqs/{sample}.err"
+    params:
+        streme_param_string = lambda wildcards: lookup_in_config_persample(config,\
+        pep, ["motif_calling", wildcards.model, "get_peak_seq_param_string"], wildcards.sample,\
+        "--min_size 30") 
+    conda:
+        "../envs/motif_calling.yaml"
+    shell:
+        "python3 get_seqs.py {input.bed} {input.fasta} "
+        "{params.streme_param_string} "
+        "> {log.stdout} 2> {log.stderr}"
+
+
+rule streme_call_motifs:
+    input:
+        "results/motif_calling/{model}/get_peak_seqs/{sample}.fa"
+    output:
+        "results/motif_calling/{model}/streme/{sample}/sequences.tsv",
+        "results/motif_calling/{model}/streme/{sample}/streme.txt",
+        "results/motif_calling/{model}/streme/{sample}/streme.html"
+    log:
+        stdout="results/motif_calling/logs/{model}/streme/{sample}_streme.log",
+        stderr="results/motif_calling/logs/{model}/streme/{sample}_streme.err"
+    params:
+        streme_param_string = lambda wildcards: lookup_in_config_persample(config,\
+        pep, ["motif_calling", wildcards.model, "streme_param_string"], wildcards.sample,\
+        "--dna --minw 8 --maxw 15") 
+    conda:
+        "../envs/motif_calling.yaml"
+    shell:
+        "streme --p {input.ext} "
+        "--o results/motif_calling/{wildcards.model}/streme/{wildcards.sample}/ "
+        "{params.streme_param_string} "
+        "> {log.stdout} 2> {log.stderr}"

--- a/workflow/rules/peak_calling.smk
+++ b/workflow/rules/peak_calling.smk
@@ -18,12 +18,18 @@ def determine_peak_calling_files(config, pep):
         err = "Need peak caller specified for peak_caller model %s in config file. I.e. \npeak_calling:\n\t%s:\n\t\tpeak_caller: 'macs2'"%(model,model))
         these_samples = filter_samples(pep, \
         lookup_in_config(config, ["peak_calling", model, "filter"], "not input_sample.isnull()"))
+        if peak_caller == "macs2_broad":
+            for sample in these_samples:
+                outfiles.append("results/peak_calling/%s/macs2/%s_peaks.broadPeak"%(model, sample))
         if peak_caller == "macs2":
             for sample in these_samples:
-                outfiles.append("results/peak_calling/%s/macs2/%s_peaks.xls"%(model, sample))
+                outfiles.append("results/peak_calling/%s/macs2/%s_peaks.narrowPeak"%(model, sample))
         if peak_caller == "cmarrt":
             for sample in these_samples:
                 outfiles.append("results/peak_calling/%s/cmarrt/%s.narrowPeak"%(model,sample))
+        if peak_caller == "macs3":
+            for sample in these_samples:
+                outfiles.append("results/peak_calling/%s/macs3/%s_peaks.xls"%(model, sample))
     return outfiles
 
 rule run_peak_calling:
@@ -72,19 +78,69 @@ rule macs2_call_peaks:
         inp = lambda wildcards: get_macs2_matching_input(wildcards.sample, pep),
         genome_size= lambda wildcards: determine_effective_genome_size_file(wildcards.sample, config, pep)
     output:
-        "results/peak_calling/{model}/macs2/{sample}_peaks.xls"
+        "results/peak_calling/{model}/macs2/{sample}_summits.bed",
+        "results/peak_calling/{model}/macs2/{sample}_peaks.narrowPeak"
     log:
         stdout="results/peak_calling/logs/{model}/macs2/{sample}_macs2.log",
         stderr="results/peak_calling/logs/{model}/macs2/{sample}_macs2.err"
     params:
         macs2_param_string = lambda wildcards: lookup_in_config_persample(config,\
         pep, ["peak_calling", wildcards.model, "macs2_param_string"], wildcards.sample,\
-        "-f BAMPE --broad") 
+        "-f BAMPE ") 
     conda:
         "../envs/peak_calling.yaml"
     shell:
         "macs2 callpeak -t {input.ext} -c {input.inp} -n {wildcards.sample} "
         "--outdir results/peak_calling/{wildcards.model}/macs2/ "
+        "--call-summits "
         "{params.macs2_param_string} "
         "-g $(cat {input.genome_size}) > {log.stdout} 2> {log.stderr}"
 
+
+rule macs2_broad_call_peaks:
+    input:
+        ext = "results/alignment/bowtie2/{sample}_sorted.bam",
+        inp = lambda wildcards: get_macs2_matching_input(wildcards.sample, pep),
+        genome_size= lambda wildcards: determine_effective_genome_size_file(wildcards.sample, config, pep)
+    output:
+        "results/peak_calling/{model}/macs2/{sample}_peaks.broadPeak"
+    log:
+        stdout="results/peak_calling/logs/{model}/macs2/{sample}_macs2.log",
+        stderr="results/peak_calling/logs/{model}/macs2/{sample}_macs2.err"
+    params:
+        macs2_param_string = lambda wildcards: lookup_in_config_persample(config,\
+        pep, ["peak_calling", wildcards.model, "macs2_param_string"], wildcards.sample,\
+        "-f BAMPE ") 
+    conda:
+        "../envs/peak_calling.yaml"
+    shell:
+        "macs2 callpeak -t {input.ext} -c {input.inp} -n {wildcards.sample} "
+        "--outdir results/peak_calling/{wildcards.model}/macs2/ "
+        "--broad "
+        "{params.macs2_param_string} "
+        "-g $(cat {input.genome_size}) > {log.stdout} 2> {log.stderr}"
+
+rule macs3_call_peaks:
+    input:
+        ext = "results/alignment/bowtie2/{sample}_sorted.bam",
+        inp = lambda wildcards: get_macs2_matching_input(wildcards.sample, pep),
+        genome_size= lambda wildcards: determine_effective_genome_size_file(wildcards.sample, config, pep)
+    output:
+        "results/peak_calling/{model}/macs3/{sample}_peaks.xls",
+        "results/peak_calling/{model}/macs3/{sample}_summits.bed",
+        "results/peak_calling/{model}/macs3/{sample}.narrowPeak"
+    log:
+        stdout="results/peak_calling/logs/{model}/macs3/{sample}_macs3.log",
+        stderr="results/peak_calling/logs/{model}/macs3/{sample}_macs3.err"
+    params:
+        macs3_param_string = lambda wildcards: lookup_in_config_persample(config,\
+        pep, ["peak_calling", wildcards.model, "macs3_param_string"], wildcards.sample,\
+        "-f BAMPE --broad") 
+    conda:
+        "../envs/peak_calling.yaml"
+    shell:
+        "macs3 callpeak -t {input.ext} -c {input.inp} -n {wildcards.sample} "
+        "--outdir results/peak_calling/{wildcards.model}/macs3/ "
+        "--call-summits "
+        "{params.macs3_param_string} "
+        "-g $(cat {input.genome_size}) > {log.stdout} 2> {log.stderr}" 

--- a/workflow/scripts/bed_to_fasta.py
+++ b/workflow/scripts/bed_to_fasta.py
@@ -1,0 +1,82 @@
+import fasta
+import bed_utils
+import argparse
+
+def determine_start_end(feature, chrm, args):
+    if args.centered:
+        center = round((feature["start"] + feature["end"])/2)
+        start = center
+        end = center
+    else:
+        start = feature["start"]
+        end = feature["end"]
+
+    if feature["strand"] == "-":
+        final_start = max(start - args.downstream, 0)
+        final_end = min(end + args.upstream, len(chrm))
+        final_rc = True
+    else:
+        final_start = max(start - args.upstream, 0)
+        final_end = min(end + args.downstream, len(chrm))
+        final_rc = False
+    return(final_start, final_end, final_rc)
+
+def determine_header(chrm, start, end, strand, name, args):
+    if args.meme_header:
+        return ">%s:%d-%d"%(chrm, start+1, end)
+    else:
+        return ">%s;%d;%d;%s;%s"%(chrm, start, end, strand,name)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Convert bed to fasta")
+    parser.add_argument("infile", type=str, help="path to input file")
+    parser.add_argument("infasta", type=str, help="path to input fasta")
+    parser.add_argument("outfile", type=str, help="path to output file")
+    parser.add_argument("--centered", action = "store_true", help = "make everything relative to region center")
+    parser.add_argument("--upstream", type = int, help = "# of bp to pad upstream. - numbers cut into region", default = 0)
+    parser.add_argument("--downstream", type = int, help = "# of bp to pad downstream. - numbers cut into region", default = 0)
+    parser.add_argument("--min_size", type = int, help = "minimum sequence length. Filters anything shorter than this after padding is applied")
+    parser.add_argument("--meme_header", action = "store_true", help = "make the fasta entry header conform to memes expectations")
+    parser.add_argument("--include_unstranded_rc", action="store_true", 
+            help="include reverse complement of unstranded features?")
+
+    # Read in bed file
+    args = parser.parse_args()
+    inbed = bed_utils.BedFile()
+    inbed.from_bed_file(args.infile)
+
+    # read in fasta file
+    infasta = fasta.FastaFile()
+    with open(args.infasta) as inf:
+        infasta.read_whole_file(inf)
+    outfasta = fasta.FastaFile()
+
+
+    # convert beds to fastas
+    for entry in inbed:
+        this_chrm = infasta.pull_entry(entry["chrm"])
+        # if you don't know the strand put both the complement and 
+        # reverse complement
+        this_start, this_end, this_rc = determine_start_end(entry, this_chrm, args) 
+        if (args.min_size is not None):
+            if (this_end - this_start) < args.min_size:
+                continue
+        if entry["strand"] == ".":
+            new_fasta_c = fasta.FastaEntry()
+            new_fasta_c.set_header(determine_header(entry["chrm"], this_start, this_end, "+", entry["name"], args))
+            new_fasta_c.set_seq(this_chrm.pull_seq(this_start, this_end, rc = False))
+            outfasta.add_entry(new_fasta_c)
+            if args.include_unstranded_rc:
+                new_fasta_rc = fasta.FastaEntry() 
+                new_fasta_rc.set_header(determine_header(entry["chrm"], this_start, this_end, "-", entry["name"], args))
+                new_fasta.rc.set_seq(this_chrm.pull_seq(this_start, this_end, rc = True))
+                outfasta.add_entry(new_fasta_rc)
+
+        else:
+            new_fasta = fasta.FastaEntry()
+            new_fasta.set_header(determine_header(entry["chrm"], this_start, this_end, entry["strand"], entry["name"], args))
+            new_fasta.set_seq(this_chrm.pull_seq(this_start, this_end,rc = this_rc))
+            outfasta.add_entry(new_fasta)
+
+    with open(args.outfile, mode="w") as outf:
+        outfasta.write(outf)

--- a/workflow/scripts/bed_utils.py
+++ b/workflow/scripts/bed_utils.py
@@ -89,7 +89,7 @@ class BedFile(object):
     def add_entry(self, entry):
         self.data.append(entry)
     def sort(self):
-        self.data.sort(key = lambda a: a['start'])
+        self.data.sort(key = lambda a: (a['chrm'], a['start']))
     def cleanup(self):
         """
         Remove all duplicate entries, entries are mutable therefore not hashable

--- a/workflow/scripts/combine_bed.py
+++ b/workflow/scripts/combine_bed.py
@@ -1,0 +1,25 @@
+import bed_utils 
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser("Combine bed files into one bed file. Removes duplicate entries and sorts by chrm, start")
+    parser.add_argument('outfilepre', type=str, help="prefix for output files")
+    parser.add_argument('infiles', type=str, nargs='+', help="files to combine")
+    
+    args = parser.parse_args()
+
+    bed_files = args.infiles
+    all_beds = [bed_utils.BedFile() for inf in bed_files]
+
+    for bedobj, bed_file in zip(all_beds, bed_files):
+        bedobj.from_bed_file(bed_file)
+    final_bed = bed_utils.BedFile()
+    for bedobj in all_beds:
+        for entry in bedobj:
+            final_bed.add_entry(entry)
+    final_bed.cleanup()
+    final_bed.sort()
+    final_bed.write_bed_file(args.outfilepre + ".bed")
+
+
+


### PR DESCRIPTION
## 0.2.9 - 2022-05-26

### Added
- Add a motif calling module. Supports both `meme` and `streme` motif callers
- Added fimo calling with discovered motifs
- Add ability get coverage around the set of peaks for each sample
- Combine bed files from each chromosome into one master bed file
- Create an annotation file that maps unique name to locus tags and gene names

### Changed
- Split macs2 broad and macs2 default into their own peak callers. Always call
  summits when running macs2 without broad specified