### PR TITLE
Update to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Develop
+
+### Added
+- Fixed traveling ratio which centers the promoter proximal window at the first
+  coordinate of the given region
+
+### Changes
+- Relaxed size restriction on traveling ratios to be twice the window size. Down
+  from 1000 bp
+
+### Bug fixes
+- Calculation of the center coordinate for traveling ratios was fixed
+
 ## 0.2.9 - 2022-05-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Fixed traveling ratio which centers the promoter proximal window at the first
-  coordinate of the given region
+  coordinate of the given region.
+- Ability to specify window sizes to traveling ratio as well as window A center for
+  fixed traveling ratios
 - Ability to get raw read counts for a given set of windows and samples
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Develop
 
 ### Added
+- A `run_annotations` rule to pull an annotation table for each genome specified
+  in the config file
+- Ability to get relative coordinates out of postprocessing summaries
 - Spike-in quality control by reporting fragments per contig per sample
 - Fixed traveling ratio which centers the promoter proximal window at the first
   coordinate of the given region.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Develop
 
 ### Added
+- Spike-in quality control by reporting fragments per contig per sample
 - Fixed traveling ratio which centers the promoter proximal window at the first
   coordinate of the given region.
 - Ability to specify window sizes to traveling ratio as well as window A center for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the config file
 - Ability to get relative coordinates out of postprocessing summaries
 - Spike-in quality control by reporting fragments per contig per sample
-- Fixed traveling ratio which centers the promoter proximal window at the first
-  coordinate of the given region.
 - Ability to specify window sizes to traveling ratio as well as window A center for
   fixed traveling ratios
 - Ability to get raw read counts for a given set of windows and samples
+
+### Changes
+- Fixed traveling ratio which centers the promoter proximal window at the first
+  coordinate of the given region.
+
+### Bug fixes
+- Fixed multiqc config file to report fastqc results both before and after
+  trimming
 
 ### Changes
 - Relaxed size restriction on traveling ratios to be twice the window size. Down

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Develop
+## 0.3.0 - 2023-07-15
 
 ### Added
 - A `run_annotations` rule to pull an annotation table for each genome specified
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug fixes
 - Fixed multiqc config file to report fastqc results both before and after
   trimming
+- Fixed issue with quality control where PE fragment size determination failed
+  when sample sheets had both SE and PE samples
 
 ### Changes
 - Relaxed size restriction on traveling ratios to be twice the window size. Down

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Fixed traveling ratio which centers the promoter proximal window at the first
   coordinate of the given region
+- Ability to get raw read counts for a given set of windows and samples
 
 ### Changes
 - Relaxed size restriction on traveling ratios to be twice the window size. Down

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ If you run into any issues with the pipeline and would like help please submit i
 # Version history
 
 
-Currently at version 0.2.9
+Currently at version 0.3.0
 
 
 See the [Changelog](CHANGELOG.md) for version history and upcoming

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -421,7 +421,7 @@ postprocessing:
 
         # Model 5 - look at the identified beta peak locations for the traveling
         # ratio
-        genotypeA_all_genes_TR:
+        genotypeA_all_genes_summit_loc:
             # only consider the samples that have a genotype A
             filter: 'genotype == "A" and not input_sample.isnull()'
             # which regions to use?
@@ -438,6 +438,30 @@ postprocessing:
             summarize: "single"
             # What single number summary do you want (mean, median, max, min)
             # only defined when summarize is "single"
-            summary_func: "TR"
+            summary_func: "summit_loc"
+            # what fraction of NaNs can be in a region and still report a value?
+            frac_na: 0.20
+
+
+        # Model 6 - look at the identified beta peak locations for the traveling
+        # ratio
+        genotypeA_all_genes_TR_fixed:
+            # only consider the samples that have a genotype A
+            filter: 'genotype == "A" and not input_sample.isnull()'
+            # which regions to use?
+            regions: "results/alignment/process_genbank/U00096.3/U00096.3.bed"
+            # which files to use?
+            filesignature: "results/coverage_and_norm/deeptools_coverage/%s_raw.bw"
+            # Here we want to consider 300 bp upstream in our region as well
+            upstream: 300
+            # what resolution to query data (shouldn't be lower than the
+            # resolution of your file
+            res : 5
+            # How do you want to summarize your data? (identity gives every data
+            # point in tidy format, single allows for a single number summary)
+            summarize: "single"
+            # What single number summary do you want (mean, median, max, min)
+            # only defined when summarize is "single"
+            summary_func: "TR_fixed"
             # what fraction of NaNs can be in a region and still report a value?
             frac_na: 0.20

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -465,3 +465,15 @@ postprocessing:
             summary_func: "TR_fixed"
             # what fraction of NaNs can be in a region and still report a value?
             frac_na: 0.20
+
+    # get *read* coverage per region
+    deeptools_readcount:
+        genotypeA_all_genes:
+            # which regions to use? Specifying a file like this has the pipeline
+            # parse it from your genbank file given the process genbank
+            # parameters above in the alignment section
+            regions: "results/alignment/combine_bed/U00096.3/U00096.3.bed"
+            # only consider the samples that have a genotype A.
+            filter: 'genotype == "A"'
+
+

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -463,6 +463,7 @@ postprocessing:
             # What single number summary do you want (mean, median, max, min)
             # only defined when summarize is "single"
             summary_func: "TR_fixed"
+            bwtools_query_params: "--TR_A_center 40 "
             # what fraction of NaNs can be in a region and still report a value?
             frac_na: 0.20
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -347,6 +347,10 @@ postprocessing:
             # what resolution to query data (shouldn't be lower than the
             # resolution of your file
             res : 5
+            # Specify how you want the coordinates to be reported in. Options
+            # include "relative_start", "relative_end", "relative_center" and
+            # "absolute". Default is "absolute"
+            coord: "relative_end"
             # How do you want to summarize your data? (identity gives every data
             # point in tidy format)
             summarize: "identity"

--- a/workflow/envs/multiqc_config.yaml
+++ b/workflow/envs/multiqc_config.yaml
@@ -5,15 +5,15 @@ module_order:
         info: 'FastQC results after adapter trimming.'
         target: ''
         path_filters:
-            - '*trim*fastqc.zip'
+            - '*/fastqc_processed/*fastqc.zip'
     - trimmomatic
     - cutadapt
     - fastqc:
         name: 'FastQC (raw)'
         info: "FastQC results on the raw files (filenames may differ)"
         anchor: 'fastqc_raw'
-        path_filters_exclude:
-            - '*trim*fastqc.zip'
+        path_filters:
+            - '*/fastqc_raw/*fastqc.zip'
 
 report_section_order:
     fastq_trimmed:

--- a/workflow/rules/alignment.smk
+++ b/workflow/rules/alignment.smk
@@ -12,6 +12,11 @@ rule run_alignment:
     input:
         expand("results/alignment/bowtie2/{sample}_sorted.bam.bai", sample = samples(pep))
 
+rule run_annotations:
+    input:
+        expand("results/alignment/combine_bed/{genome}/{genome}.bed", genome = config["reference"].keys()),
+        expand("results/alignment/combine_bed/{genome}/{genome}_annotations.tsv", genome = config["reference"].keys())
+
 def get_genome_fastas(config, genome):
     return config["reference"][genome]["fastas"]
 

--- a/workflow/rules/postprocessing.smk
+++ b/workflow/rules/postprocessing.smk
@@ -179,6 +179,7 @@ rule bwtools_query:
         res = lambda wildcards: lookup_in_config(config, ["postprocessing", "bwtools_query", wildcards.model, "res"], 5),
         summarize = lambda wildcards: lookup_in_config(config, ["postprocessing", "bwtools_query", wildcards.model, "summarize"], 'single'),
         summary_func = lambda wildcards: lookup_in_config(config, ["postprocessing", "bwtools_query", wildcards.model, "summary_func"], 'mean'),
+        coord = lambda wildcards: lookup_in_config(config, ["postprocessing", "bwtools_query", wildcards.model, "coord"], 'absolute'),
         frac_na = lambda wildcards: lookup_in_config(config, ["postprocessing", "bwtools_query", wildcards.model, "frac_na"], 0.25),
         bwtools_query_params = lambda wildcards: lookup_in_config(config, ["postprocessing", "bwtools_query", wildcards.model, "bwtools_query_params"], " ")
     threads:
@@ -191,6 +192,7 @@ rule bwtools_query:
         "{input.inbws} "
         "--res {params.res} "
         "--regions {input.inbed} "
+        "--coords {params.coord} "
         "--upstream {params.upstream} "
         "--downstream {params.downstream} "
         "--samp_names {params.labels} "

--- a/workflow/rules/postprocessing.smk
+++ b/workflow/rules/postprocessing.smk
@@ -179,7 +179,8 @@ rule bwtools_query:
         res = lambda wildcards: lookup_in_config(config, ["postprocessing", "bwtools_query", wildcards.model, "res"], 5),
         summarize = lambda wildcards: lookup_in_config(config, ["postprocessing", "bwtools_query", wildcards.model, "summarize"], 'single'),
         summary_func = lambda wildcards: lookup_in_config(config, ["postprocessing", "bwtools_query", wildcards.model, "summary_func"], 'mean'),
-        frac_na = lambda wildcards: lookup_in_config(config, ["postprocessing", "bwtools_query", wildcards.model, "frac_na"], 0.25)
+        frac_na = lambda wildcards: lookup_in_config(config, ["postprocessing", "bwtools_query", wildcards.model, "frac_na"], 0.25),
+        bwtools_query_params = lambda wildcards: lookup_in_config(config, ["postprocessing", "bwtools_query", wildcards.model, "bwtools_query_params"], " ")
     threads:
         5
     conda:
@@ -197,6 +198,7 @@ rule bwtools_query:
         "--summary_func {params.summary_func} "
         "--frac_na {params.frac_na} "
         "--gzip "
+        "{params.bwtools_query_params} "
         "> {log.stdout} 2> {log.stderr} "
 
 rule spearman_per_gene:

--- a/workflow/rules/quality_control.smk
+++ b/workflow/rules/quality_control.smk
@@ -20,6 +20,42 @@ rule run_quality_control:
         "multiqc results/ -o results/quality_control/ --config workflow/envs/multiqc_config.yaml"
 
 
+## spike-in QC
+
+rule frags_per_contig:
+    input:
+        infile = "results/alignment/bowtie2/{sample}_sorted.bam",
+        inidx = "results/alignment/bowtie2/{sample}_sorted.bam.bai"
+    output:
+        "results/quality_control/frags_per_contig/{sample}_frags_per_contig.tsv"
+    threads: 1
+    conda:
+        "../envs/alignment.yaml"
+    log:
+        stderr = "results/quality_control/logs/frags_per_contig/{sample}_frags_per_contig.err"
+    params:
+        samtools_param_string= lambda wildcards: lookup_in_config_persample(config,\
+        pep, ["quality_control", "frags_per_contig", "samtools_param_string"], wildcards.sample,\
+        "-f 67")
+    shell:
+        "samtools view {params.samtools_param_string} {input.infile} | python3 workflow/scripts/fragments_per_contig.py > "
+        "{output} 2> {log.stderr}"
+
+rule combine_frags_per_contig:
+    input:
+        expand("results/quality_control/frags_per_contig/{sample}_frags_per_contig.tsv", sample = samples(pep))
+    output:
+        "results/quality_control/frags_per_contig/all_samples.tsv"
+    threads: 1
+    conda:
+        "../envs/R.yaml"
+    log:
+        stderr = "results/quality_control/logs/frags_per_contig/all_samples.err",
+        stdout = "results/quality_control/logs/frags_per_contig/all_samples.log"
+    shell:
+        "Rscript workflow/scripts/combine_frags_per_contig.R {input} > {log.stdout} 2> {log.stderr}"
+
+
 
 # General read QC
 def fastqc_files_output(pep, type_string = "processed"):
@@ -106,50 +142,17 @@ def qc_groups(config, pep):
     column = determine_grouping_category(config)
     return pep.sample_table[column].unique().tolist()
 
-## spike-in QC
-
-rule frags_per_contig:
-    input:
-        infile = "results/alignment/bowtie2/{sample}_sorted.bam",
-        inidx = "results/alignment/bowtie2/{sample}_sorted.bam.bai"
-    output:
-        "results/quality_control/frags_per_contig/{sample}_frags_per_contig.tsv"
-    threads: 1
-    conda:
-        "../envs/alignment.yaml"
-    log:
-        stderr = "results/quality_control/logs/frags_per_contig/{sample}_frags_per_contig.err"
-    params:
-        samtools_param_string= lambda wildcards: lookup_in_config_persample(config,\
-        pep, ["quality_control", "frags_per_contig", "samtools_param_string"], wildcards.sample,\
-        "-f 67")
-    shell:
-        "samtools view {params.samtools_param_string} {input.infile} | python3 workflow/scripts/fragments_per_contig.py > "
-        "{output} 2> {log.stderr}"
-
-rule combine_frags_per_contig:
-    input:
-        expand("results/quality_control/frags_per_contig/{sample}_frags_per_contig.tsv", sample = samples(pep))
-    output:
-        "results/quality_control/frags_per_contig/all_samples.tsv"
-    threads: 1
-    conda:
-        "../envs/R.yaml"
-    log:
-        stderr = "results/quality_control/logs/frags_per_contig/all_samples.err",
-        stdout = "results/quality_control/logs/frags_per_contig/all_samples.log"
-    shell:
-        "Rscript workflow/scripts/combine_frags_per_contig.R {input} > {log.stdout} 2> {log.stderr}"
+def get_pe_samples(pep):
+    return filter_samples(pep, "not filenameR2.isnull()")
 
 # OVERALL RULE FOR ChIP QC
 
 rule ChIP_QC:
     input:
         expand("results/quality_control/deeptools_QC/fingerprint/{group}_fingerprint.png", group = qc_groups(config, pep)),
-        #expand("deeptools_QC/{samps}_GCBias_freqs.txt", samps=samples(pep)),
         expand("results/quality_control/deeptools_QC/corHeatmap/{group}_corHeatmap.png", group = qc_groups(config, pep)),
         expand("results/quality_control/deeptools_QC/corScatter/{group}_corScatterplot.png", group = qc_groups(config, pep)),
-        expand("results/quality_control/deeptools_QC/fragment_sizes/{group}_bamPEFragmentSize.png", group = qc_groups(config, pep)),
+        expand("results/quality_control/deeptools_QC/fragment_sizes/bamPEFragmentSize.png", group = qc_groups(config, pep)),
         expand("results/quality_control/deeptools_QC/plotCoverage_rmdups/{group}_plotCoverage_rmdups.png", group = qc_groups(config, pep)),
         expand("results/quality_control/deeptools_QC/plotCoverage/{group}_plotCoverage.png", group = qc_groups(config, pep)),
         expand("results/quality_control/deeptools_QC/PCA/{group}_plotPCA.png", group = qc_groups(config, pep))
@@ -167,7 +170,10 @@ rule deeptools_QC_fingerprint:
         qualmetrics="results/quality_control/deeptools_QC/fingerprint/{group}_fingerprint_qual_metrics.txt"
     params:
         labels = lambda wildcards: " ".join([samp for samp in get_sample_by_group(wildcards.group, pep)]),
-        bams = lambda wildcards: " ".join(["results/alignment/bowtie2/%s_sorted.bam"%samp for samp in get_sample_by_group(wildcards.group, pep)])
+        bams = lambda wildcards: " ".join(["results/alignment/bowtie2/%s_sorted.bam"%samp for samp in get_sample_by_group(wildcards.group, pep)]),
+        binsize = lookup_in_config(config, ["quality_control", "plotFingerprint", "binsize"], 500),
+        num_samps = lookup_in_config(config, ["quality_control", "plotFingerprint", "num_samps"], 9200),
+        bamCoverage_params = lookup_in_config(config, ["quality_control", "bamCoverage_params"], " ")
     conda:
         "../envs/quality_control.yaml"
     threads:
@@ -180,10 +186,10 @@ rule deeptools_QC_fingerprint:
         "plotFingerprint -b {params.bams} --plotFile {output.outplot} "
         "--outRawCounts {output.rawcounts} --outQualityMetrics {output.qualmetrics} "
         "--labels {params.labels} "
-        "--binSize 500 "
-        "--numberOfSamples 9200 --numberOfProcessors {threads} --extendReads "
-        "--minMappingQuality 10 "
-        "--samFlagInclude 66 > {log.stdout} 2> {log.stderr}"
+        "--binSize {params.binsize} "
+        "--numberOfSamples {params.num_samps} --numberOfProcessors {threads} "
+        "{params.bamCoverage_params} "
+        "> {log.stdout} 2> {log.stderr}"
 
 rule deeptools_QC_multiBamSummary:
     input: 
@@ -193,7 +199,9 @@ rule deeptools_QC_multiBamSummary:
         "results/quality_control/deeptools_QC/{group}_coverage_matrix.npz"
     params:
         labels = lambda wildcards: " ".join([samp for samp in get_sample_by_group(wildcards.group, pep)]),
-        bams = lambda wildcards: " ".join(["results/alignment/bowtie2/%s_sorted.bam"%samp for samp in get_sample_by_group(wildcards.group, pep)])
+        bams = lambda wildcards: " ".join(["results/alignment/bowtie2/%s_sorted.bam"%samp for samp in get_sample_by_group(wildcards.group, pep)]),
+        binsize = lookup_in_config(config, ["quality_control", "multiBamSummary", "binsize"], 1000),
+        bamCoverage_params = lookup_in_config(config, ["quality_control", "bamCoverage_params"], "--extendReads --samFlagInclude 67")
     threads:
         10
     log:
@@ -204,10 +212,10 @@ rule deeptools_QC_multiBamSummary:
     shell:
         "multiBamSummary bins -b {params.bams} -o {output} "
         "--labels {params.labels} "
-        "--binSize 1000 "
-        "--numberOfProcessors {threads} --extendReads "
-        "--minMappingQuality 10 "
-        "--samFlagInclude 66 > {log.stdout} 2> {log.stderr}"
+        "--binSize {params.binsize} "
+        "--numberOfProcessors {threads} "
+        "{params.bamCoverage_params} "
+        "> {log.stdout} 2> {log.stderr}"
 
 rule deeptools_QC_corHeatmap:
     input:
@@ -217,7 +225,7 @@ rule deeptools_QC_corHeatmap:
         cormat="results/quality_control/deeptools_QC/corHeatmap/{group}_corvalues.txt"
     log:
         stdout="results/quality_control/logs/deeptools_QC/corHeatmap/{group}_corHeatmap.log",
-        stderr="results/quality_control/logs/deeptools_QC/corHetamap/{group}_corHeatmap.err"
+        stderr="results/quality_control/logs/deeptools_QC/corHeatmap/{group}_corHeatmap.err"
     conda:
         "../envs/quality_control.yaml"
     shell:
@@ -266,7 +274,9 @@ rule deeptools_QC_plotCoverage:
         counts="results/quality_control/deeptools_QC/plotCoverage/{group}_plotCoverage_count.txt"
     params:
         labels = lambda wildcards: " ".join([samp for samp in get_sample_by_group(wildcards.group, pep)]),
-        bams = lambda wildcards: " ".join(["results/alignment/bowtie2/%s_sorted.bam"%samp for samp in get_sample_by_group(wildcards.group, pep)])
+        bams = lambda wildcards: " ".join(["results/alignment/bowtie2/%s_sorted.bam"%samp for samp in get_sample_by_group(wildcards.group, pep)]),
+        num_samps = lookup_in_config(config, ["quality_control", "plotCoverage", "num_samps"], 1000),
+        bamCoverage_params = lookup_in_config(config, ["quality_control", "bamCoverage_params"], " ")
     threads:
         10
     log:
@@ -277,11 +287,11 @@ rule deeptools_QC_plotCoverage:
     shell:
         "plotCoverage -b {params.bams} -o {output.plot} "
         "--labels {params.labels} "
-        "--numberOfProcessors {threads} --extendReads "
-        "--numberOfSamples 1000 "
+        "--numberOfProcessors {threads} "
+        "--numberOfSamples {params.num_samps} "
         "--outRawCounts {output.counts} "
-        "--minMappingQuality 10 "
-        "--samFlagInclude 66 > {log.stdout} 2> {log.stderr}"
+        "{params.bamCoverage_params} "
+        "> {log.stdout} 2> {log.stderr}"
 
 rule deeptools_QC_plotCoverage_rmdups:
     input: 
@@ -292,7 +302,9 @@ rule deeptools_QC_plotCoverage_rmdups:
         counts="results/quality_control/deeptools_QC/plotCoverage_rmdups/{group}_plotCoverage_count_rmdups.txt"
     params:
         labels = lambda wildcards: " ".join([samp for samp in get_sample_by_group(wildcards.group, pep)]),
-        bams = lambda wildcards: " ".join(["results/alignment/bowtie2/%s_sorted.bam"%samp for samp in get_sample_by_group(wildcards.group, pep)])
+        bams = lambda wildcards: " ".join(["results/alignment/bowtie2/%s_sorted.bam"%samp for samp in get_sample_by_group(wildcards.group, pep)]),
+        num_samps = lookup_in_config(config, ["quality_control", "plotCoverage", "num_samps"], 1000),
+        bamCoverage_params = lookup_in_config(config, ["quality_control", "bamCoverage_params"], " ")
     threads:
         10
     log:
@@ -303,28 +315,29 @@ rule deeptools_QC_plotCoverage_rmdups:
     shell:
         "plotCoverage -b {params.bams} --plotFile {output.plot} "
         "--labels {params.labels} "
-        "--numberOfProcessors {threads} --extendReads --ignoreDuplicates "
-        "--numberOfSamples 1000 "
+        "--numberOfProcessors {threads} --ignoreDuplicates "
+        "--numberOfSamples {params.num_samps} "
         "--outRawCounts {output.counts} "
-        "--minMappingQuality 10 "
-        "--samFlagInclude 66 > {log.stdout} 2> {log.stderr}"
+        "{params.bamCoverage_params} "
+        "> {log.stdout} 2> {log.stderr}"
 
 rule deeptools_QC_bamPEFragmentSize:
     input:
-        lambda wildcards: ["results/alignment/bowtie2/%s_sorted.bam"%samp for samp in get_sample_by_group(wildcards.group, pep)],
-        lambda wildcards: ["results/alignment/bowtie2/%s_sorted.bam.bai"%samp for samp in get_sample_by_group(wildcards.group, pep)]
+        lambda wildcards: ["results/alignment/bowtie2/%s_sorted.bam"%samp for samp in get_pe_samples(pep)],
+        lambda wildcards: ["results/alignment/bowtie2/%s_sorted.bam.bai"%samp for samp in get_pe_samples(pep)]
     output:
-        plot="results/quality_control/deeptools_QC/fragment_sizes/{group}_bamPEFragmentSize.png",
-        fragment_hist="results/quality_control/deeptools_QC/fragment_sizes/{group}_bamPEFragmentSize.txt",
-        table="results/quality_control/deeptools_QC/fragment_sizes/{group}_bamPEFragmentSize_table.txt"
+        plot="results/quality_control/deeptools_QC/fragment_sizes/bamPEFragmentSize.png",
+        fragment_hist="results/quality_control/deeptools_QC/fragment_sizes/bamPEFragmentSize.txt",
+        table="results/quality_control/deeptools_QC/fragment_sizes/bamPEFragmentSize_table.txt"
     params:
-        labels = lambda wildcards: " ".join([samp for samp in get_sample_by_group(wildcards.group, pep)]),
-        bams = lambda wildcards: " ".join(["results/alignment/bowtie2/%s_sorted.bam"%samp for samp in get_sample_by_group(wildcards.group, pep)])
+        labels = lambda wildcards: " ".join([samp for samp in get_pe_samples(pep)]),
+        bams = lambda wildcards: " ".join(["results/alignment/bowtie2/%s_sorted.bam"%samp for samp in get_pe_samples(pep)]),
+        num_samps = lookup_in_config(config, ["quality_control", "bamPEFragSize", "bin_dist"], 10000),
     threads:
         10
     log:
-        stdout="results/quality_control/logs/deeptools_QC/fragment_sizes/{group}_bamPEFragmentSize.log",
-        stderr="results/quality_control/logs/deeptools_QC/fragment_sizes/{group}_bamPEFragmentSize.err"
+        stdout="results/quality_control/logs/deeptools_QC/fragment_sizes/bamPEFragmentSize.log",
+        stderr="results/quality_control/logs/deeptools_QC/fragment_sizes/bamPEFragmentSize.err"
     conda:
         "../envs/quality_control.yaml"
     shell:
@@ -333,28 +346,3 @@ rule deeptools_QC_bamPEFragmentSize:
         "--numberOfProcessors {threads} "
         "--distanceBetweenBins 10000 "
         "--table {output.table} --outRawFragmentLengths {output.fragment_hist}  > {log.stdout} 2> {log.stderr}"
-
-# WORK IN PROGRESS
-rule deeptools_QC_computeGCBias:
-    input: 
-        "results/bowtie2/{sample}_sorted.bam"
-    output:
-        gcfile="results/quality_control/deeptools_QC/GCbias/{sample}_GCBias_freqs.txt",
-        gcplot="results/quality_control/deeptools_QC/GCbias/{sample}_GCBias_plot.png"
-    threads:
-        5
-    log:
-        stdout="results/quality_control/logs/deeptools_QC/{sample}_GCBias.log",
-        stderr="results/quality_control/logs/deeptools_QC/{sample}_GCBias.err"
-    params:
-        genome_size = lambda wildcards: determine_genome_size(sample, config, pep)
-    conda:
-        "../envs/quality_control.yaml"
-    shell:
-        "computeGCBias -b {input} --effectiveGenomeSize {params.genome_size} "
-        "-g /mnt/scratch/mbwolfe/genomes/U00096_3.2bit "
-        "--sampleSize 50000 "
-        "--numberOfProcessors {threads} "
-        "--GCbiasFrequenciesFile {output.gcfile}  > {log.stdout} 2> {log.stderr}"
-
-

--- a/workflow/rules/quality_control.smk
+++ b/workflow/rules/quality_control.smk
@@ -106,6 +106,41 @@ def qc_groups(config, pep):
     column = determine_grouping_category(config)
     return pep.sample_table[column].unique().tolist()
 
+## spike-in QC
+
+rule frags_per_contig:
+    input:
+        infile = "results/alignment/bowtie2/{sample}_sorted.bam",
+        inidx = "results/alignment/bowtie2/{sample}_sorted.bam.bai"
+    output:
+        "results/quality_control/frags_per_contig/{sample}_frags_per_contig.tsv"
+    threads: 1
+    conda:
+        "../envs/alignment.yaml"
+    log:
+        stderr = "results/quality_control/logs/frags_per_contig/{sample}_frags_per_contig.err"
+    params:
+        samtools_param_string= lambda wildcards: lookup_in_config_persample(config,\
+        pep, ["quality_control", "frags_per_contig", "samtools_param_string"], wildcards.sample,\
+        "-f 67")
+    shell:
+        "samtools view {params.samtools_param_string} {input.infile} | python3 workflow/scripts/fragments_per_contig.py > "
+        "{output} 2> {log.stderr}"
+
+rule combine_frags_per_contig:
+    input:
+        expand("results/quality_control/frags_per_contig/{sample}_frags_per_contig.tsv", sample = samples(pep))
+    output:
+        "results/quality_control/frags_per_contig/all_samples.tsv"
+    threads: 1
+    conda:
+        "../envs/R.yaml"
+    log:
+        stderr = "results/quality_control/logs/frags_per_contig/all_samples.err",
+        stdout = "results/quality_control/logs/frags_per_contig/all_samples.log"
+    shell:
+        "Rscript workflow/scripts/combine_frags_per_contig.R {input} > {log.stdout} 2> {log.stderr}"
+
 # OVERALL RULE FOR ChIP QC
 
 rule ChIP_QC:

--- a/workflow/scripts/arraytools.py
+++ b/workflow/scripts/arraytools.py
@@ -172,7 +172,7 @@ def weighted_center(array, only_finite = True, normalize = False):
     Args:
         array - 1 dimensional numpy array
         only_finite - subset the array to only include finite data points?
-        normalize - divide by 1 to give a relative center?
+        normalize - divide by length to give a relative center?
     """
     if only_finite:
         finite = np.isfinite(array)
@@ -210,6 +210,6 @@ def traveling_ratio(array, wsize = 50, peak = None):
         return np.nan
 
     center_avg = np.nanmean(array[(center - wsize):(center + wsize)])
-
+    print(peak, center, len(array))
     out = center_avg/peak_avg
     return out

--- a/workflow/scripts/arraytools.py
+++ b/workflow/scripts/arraytools.py
@@ -172,7 +172,7 @@ def weighted_center(array, only_finite = True, normalize = False):
     Args:
         array - 1 dimensional numpy array
         only_finite - subset the array to only include finite data points?
-        normalize - divide by length to give a relative center?
+        normalize - divide by 1 to give a relative center?
     """
     if only_finite:
         finite = np.isfinite(array)
@@ -191,10 +191,9 @@ def relative_summit_loc(array, wsize = 50):
     peak = np.nanargmax(smoothed)
     return peak
 
-def traveling_ratio(array, wsize = 50, peak = None):
-
-    # array needs to be bigger than both windows
-    if len(array) < wsize*4:
+def traveling_ratio(array, wsize = 50, peak = None, length_cutoff = 1000):
+    # shouldn't do this with anything less than 1000 bp
+    if len(array) < length_cutoff:
         return np.nan
     # if peak isn't specified then dynamically find it
     if peak is None:
@@ -205,11 +204,11 @@ def traveling_ratio(array, wsize = 50, peak = None):
     peak_avg = np.nanmean(array[max(peak - wsize, 0):min(peak + wsize, len(array))])
     
     # center should be far enough away that windows don't overlap
-    center = int((len(array)+ peak)/2) 
-    if (center - wsize) < (peak + wsize):
+    center = int((len(array) + peak)/2)
+    if center - wsize < peak + wsize:
         return np.nan
 
     center_avg = np.nanmean(array[(center - wsize):(center + wsize)])
-    print(peak, center, len(array))
+
     out = center_avg/peak_avg
-    return out
+    return out    

--- a/workflow/scripts/arraytools.py
+++ b/workflow/scripts/arraytools.py
@@ -205,10 +205,9 @@ def traveling_ratio(array, wsize = 50, peak = None):
     peak_avg = np.nanmean(array[max(peak - wsize, 0):min(peak + wsize, len(array))])
     
     # center should be far enough away that windows don't overlap
-    center = int(len(array)/2) + peak
+    center = int((len(array)+ peak)/2) 
     if (center - wsize) < (peak + wsize):
         return np.nan
-    print(peak, center)
 
     center_avg = np.nanmean(array[(center - wsize):(center + wsize)])
 

--- a/workflow/scripts/arraytools.py
+++ b/workflow/scripts/arraytools.py
@@ -191,22 +191,26 @@ def relative_summit_loc(array, wsize = 50):
     peak = np.nanargmax(smoothed)
     return peak
 
-def traveling_ratio(array, wsize = 50, length_cutoff = 1000):
-    # shouldn't do this with anything less than 1000 bp
-    if len(array) < length_cutoff:
+def traveling_ratio(array, wsize = 50, peak = None):
+
+    # array needs to be bigger than both windows
+    if len(array) < wsize*4:
         return np.nan
-    peak = relative_summit_loc(array, wsize)
+    # if peak isn't specified then dynamically find it
+    if peak is None:
+        peak = relative_summit_loc(array, wsize)
     # peak should at the very least be in the first half of the region
     if peak >= len(array) / 2:
         return np.nan
     peak_avg = np.nanmean(array[max(peak - wsize, 0):min(peak + wsize, len(array))])
     
     # center should be far enough away that windows don't overlap
-    center = int((len(array) + peak)/2)
-    if center - wsize < peak + wsize:
+    center = int(len(array)/2) + peak
+    if (center - wsize) < (peak + wsize):
         return np.nan
+    print(peak, center)
 
     center_avg = np.nanmean(array[(center - wsize):(center + wsize)])
 
     out = center_avg/peak_avg
-    return out    
+    return out

--- a/workflow/scripts/bwtools.py
+++ b/workflow/scripts/bwtools.py
@@ -107,8 +107,10 @@ def Median_norm(arrays, pseudocount = 0):
     one_array = np.hstack(list(arrays.values()))
     one_array += pseudocount
     median = np.nanmedian(one_array)
+    if median == 0:
+        raise ValueError("Median was zero. Consider adding a pseudocount for median calculation")
     for chrm in arrays.keys():
-        arrays[chrm] = arraytools.normalize_1D(arrays[chrm], -pseudocount, median)
+        arrays[chrm] = arraytools.normalize_1D(arrays[chrm], 0, median)
     return arrays
 
 def smooth(arrays, wsize, kernel_type, edge, sigma = None):
@@ -170,6 +172,8 @@ def fixed_scale(arrays, fixed_regions = None, res = 1, summary_func = np.nanmean
         fixed_vals.extend(arrays[region["chrm"]][region["start"]//res:region["end"]//res])
     fixed_vals = np.array(fixed_vals)
     scale_val = summary_func(fixed_vals[np.isfinite(fixed_vals)])
+    if scale_factor == 0:
+        raise ValueError("Scale factor value was zero. Consider using different regions")
     for chrm in arrays.keys():
         arrays[chrm] = arraytools.normalize_1D(arrays[chrm], 0, scale_val)
     return arrays
@@ -212,6 +216,8 @@ def scale_max(arrays, num_top, res = 1):
     one_array = one_array[np.isfinite(one_array)]
     ind = np.argpartition(one_array, -num_top//res)[-num_top//res:]
     scale_factor = np.nanmedian(one_array[ind])
+    if scale_factor == 0:
+        raise ValueError("Scale factor value was zero. Consider using different regions")
 
     for chrm in arrays.keys():
         arrays[chrm] = arraytools.normalize_1D(arrays[chrm], 0, scale_factor)
@@ -229,6 +235,8 @@ def scale_region_max(arrays, number_of_regions, query_regions = None, res =1, su
         print(region + "\t" + "%s"%val)
     scale_factor = summary_func(vals)
     print("Max val: %s"%scale_factor)
+    if scale_factor == 0:
+        raise ValueError("Scale factor value was zero. Consider using different regions")
     for chrm in arrays.keys():
         arrays[chrm] = arraytools.normalize_1D(arrays[chrm], 0, scale_factor)
     return arrays
@@ -274,10 +282,11 @@ def read_multiple_bws(bw_files, res = 1):
         all_bws[fname] = bigwig_to_arrays(handle, res = res)
     return (all_bws, open_fhandles)
 
-def query_summarize_identity(all_bws, samp_names, samp_to_fname, inbed, res, gzip = False):
+def query_summarize_identity(all_bws, samp_names, samp_to_fname, inbed, res, gzip = False, coord = "absolute"):
     outvalues = {fname: [] for fname in args.infiles}
     region_names = []
     coordinates = []
+    chrm_names = []
     for region in inbed:
         for fname in args.infiles:
             these_arrays = all_bws[fname]
@@ -291,31 +300,52 @@ def query_summarize_identity(all_bws, samp_names, samp_to_fname, inbed, res, gzi
     
             these_values = these_arrays[region["chrm"]][left_coord//res:right_coord//res]
             outvalues[fname].extend(these_values)
-        these_coordinates = list(range((left_coord//res)*res,\
-                (right_coord//res)*res, res))
+        these_coordinates = np.arange((left_coord//res)*res,\
+                (right_coord//res)*res, res)
+        if coord == "relative_start":
+            if region["strand"] == "-":
+                these_coordinates = ((region["end"])//res)*res - these_coordinates - res
+            else:
+                these_coordinates = these_coordinates - (region["start"]//res)*res
+        elif coord == "relative_end":
+            if region["strand"] == "-":
+                these_coordinates = (region["start"]//res)*res - these_coordinates 
+            else:
+                these_coordinates = these_coordinates - ((region["end"])//res)*res + res
+        elif coord == "relative_center":
+            center_coord = (int((region["start"] + region["end"])/ 2)//res)*res
+            if region["strand"] == "-":
+                these_coordinates = center_coord - these_coordinates
+            else:
+                these_coordinates = these_coordinates - center_coord
+        elif coord == "absolute":
+            these_coordinates = these_coordinates
+        else:
+            raise ValueError("Coord must be one of 'relative_start', 'relative_center', 'relative_start', or 'absolute'. Not %s"%(coord))
         coordinates.extend(these_coordinates)
         region_names.extend([region["name"]]*len(these_coordinates))
+        chrm_names.extend([region["chrm"]]*len(these_coordinates))
 
-    header = "region\tcoord\t%s"%("\t".join(samp_names)) + "\n"
+    header = "chrm\tregion\tcoord\t%s"%("\t".join(samp_names)) + "\n"
     values_func = lambda i: "\t".join([str(outvalues[samp_to_fname[samp]][i]) for samp in samp_names])
     if gzip:
         with gzip.open(args.outfile, mode = "wb") as outf:
             outf.write(header.encode())
-            for i, (region, coord) in enumerate(zip(region_names, coordinates)):
-                line = "%s\t%s\t%s\n"%(region, coord, values_func(i))
+            for i, (chrm, region, coord) in enumerate(zip(chrm_names, region_names, coordinates)):
+                line = "%s\t%s\t%s\t%s\n"%(chrm, region, coord, values_func(i))
                 outf.write(line.encode())
     else:
         with open(args.outfile, mode = "w") as outf:
             outf.write(header)
-            for i, (region, coord) in enumerate(zip(region_names, coordinates)):
-                line = "%s\t%s\t%s\n"%(region, coord, values_func(i))
+            for i, (chrm, region, coord) in enumerate(zip(chrm_names, region_names, coordinates)):
+                line = "%s\t%s\t%s\t%s\n"%(chrm, region, coord, values_func(i))
                 outf.write(line)
 
 def relative_polymerase_progression(array):
     return arraytools.weighted_center(array, only_finite = True, normalize = True) 
 
-def traveling_ratio(array, res, wsize):
-    return arraytools.traveling_ratio(array, wsize = wsize//res)
+def traveling_ratio(array, res, wsize, maxsize):
+    return arraytools.traveling_ratio(array, wsize = wsize//res, length_cutoff = maxsize//res)
 
 def traveling_ratio_fixed(array, res, wsize, relative_location):
     if relative_location < wsize:
@@ -326,9 +356,11 @@ def summit_loc(array, res, wsize, upstream):
     loc = arraytools.relative_summit_loc(array, wsize = wsize//res)
     return loc*res - upstream
 
+
 def query_summarize_single(all_bws, samp_names, samp_to_fname, inbed, res, summary_func = np.nanmean, frac_na = 0.25, gzip = False):
     outvalues = {fname: [] for fname in args.infiles}
     region_names = []
+    chrm_names = []
     for region in inbed:
         for fname in args.infiles:
             these_arrays = all_bws[fname]
@@ -351,24 +383,24 @@ def query_summarize_single(all_bws, samp_names, samp_to_fname, inbed, res, summa
                 this_summary = np.nan
             outvalues[fname].append(this_summary)
         region_names.append(region["name"])
+        chrm_names.append(region["chrm"])
 
-    header = "region\t%s"%("\t".join(samp_names)) + "\n"
+    header = "chrm\tregion\t%s"%("\t".join(samp_names)) + "\n"
     values_func = lambda i: "\t".join([str(outvalues[samp_to_fname[samp]][i]) for samp in samp_names])
     if gzip:
         with gzip.open(args.outfile, mode = "wb") as outf:
             outf.write(header.encode())
-            for i, region in enumerate(region_names):
-                line = "%s\t%s\n"%(region, values_func(i))
+            for i, (chrm, region) in enumerate(zip(chrm_names, region_names)):
+                line = "%s\t%s\t%s\n"%(chrm, region, values_func(i))
                 outf.write(line.encode())
     else:
 
         with open(args.outfile, mode = "w") as outf:
             outf.write(header)
-            for i, region in enumerate(region_names):
-                line = "%s\t%s\n"%(region, values_func(i))
+            for i, (chrm, region) in enumerate(zip(chrm_names, region_names)):
+                line = "%s\t%s\t%s\n"%(chrm, region, values_func(i))
                 outf.write(line)
 
-        
 def query_main(args):
     import bed_utils
 
@@ -391,16 +423,16 @@ def query_main(args):
             'max' : np.nanmax,
             'min' : np.nanmin,
             'RPP' : relative_polymerase_progression,
-            'TR' : lambda array: traveling_ratio(array, args.res, args.wsize),
+            'TR' : lambda array: traveling_ratio(array, args.res, 50, 1000),
             'TR_fixed' : lambda array: traveling_ratio_fixed(array, args.res, args.wsize, args.upstream + args.TR_A_center),
-            'summit_loc': lambda array: summit_loc(array, args.res, args.wsize, args.upstream)}
+            'summit_loc': lambda array: summit_loc(array, args.res, 50, args.upstream)}
     try:
         summary_func = summary_funcs[args.summary_func]
     except KeyError:
         KeyError("%s is not a valid option for --summary_func"%(args.summary_func))
 
-    overall_funcs = {'identity' : query_summarize_identity,
-        'single' : lambda x, y, z, a, b, c: query_summarize_single(x, y, z, a,b, summary_func, args.frac_na, c)}
+    overall_funcs = {'identity' : lambda bws, names, smtofn, bed, res, gzip: query_summarize_identity(bws, names, smtofn, bed, res, gzip, args.coords),
+        'single' : lambda bws, names, smtofn, bed, res, gzip: query_summarize_single(bws, names, smtofn, bed,res, summary_func, args.frac_na, gzip)}
     try:
         overall_func = overall_funcs[args.summarize]
     except KeyError:
@@ -410,7 +442,7 @@ def query_main(args):
     
     for fhandle in open_fhandles:
         fhandle.close()
-
+        
 
 def summarize_main(args):
 
@@ -426,31 +458,31 @@ def summarize_main(args):
             the_finite = np.isfinite(this_array)
             outf.write("%s\t%s\n"%(chrm, np.sum(this_array[the_finite])))
 
-def compare_log2ratio(arrays1, arrays2):
+def compare_log2ratio(arrays1, arrays2, pseudocount = 0):
     out_array = {}
     for chrm in arrays1.keys():
-        out_array[chrm] = np.log2(arrays1[chrm]) - np.log2(arrays2[chrm])
+        out_array[chrm] = np.log2(arrays1[chrm] + pseudocount) - np.log2(arrays2[chrm]+pseudocount)
     return out_array
 
-def compare_divide(arrays1, arrays2):
+def compare_divide(arrays1, arrays2, pseudocount = 0):
     out_array = {}
     for chrm in arrays1.keys():
-        out_array[chrm] = arrays1[chrm] / arrays2[chrm]
+        out_array[chrm] = (arrays1[chrm]+pseudocount) / (arrays2[chrm]+pseudocount)
     return out_array
 
-def compare_subtract(arrays1, arrays2):
+def compare_subtract(arrays1, arrays2, pseudocount=0):
     out_array = {}
     for chrm in arrays1.keys():
         out_array[chrm] = arrays1[chrm] - arrays2[chrm]
     return out_array
 
-def compare_add(arrays1, arrays2):
+def compare_add(arrays1, arrays2, pseudocount = 0):
     out_array = {}
     for chrm in arrays1.keys():
         out_array[chrm] = arrays1[chrm] + arrays2[chrm]
     return out_array
 
-def compare_recipratio(arrays1, arrays2):
+def compare_recipratio(arrays1, arrays2, pseudocount = 0):
     out_array = compare_divide(arrays1, arrays2)
     for chrm in arrays1.keys():
         # figure out small values
@@ -476,7 +508,7 @@ def compare_main(args):
     arrays2 = bigwig_to_arrays(inf2, res = args.res)
 
     # perform operation
-    arrays_out = operation_dict[args.operation](arrays1, arrays2)
+    arrays_out = operation_dict[args.operation](arrays1, arrays2, args.pseudocount)
 
 
     # write out file
@@ -624,6 +656,7 @@ if __name__ == "__main__":
             help="Resolution to compute statistics at. Default 1bp. Note this \
             should be set no lower than the resolution of the input file")
     parser_query.add_argument('--regions', type=str, help = "regions to grab data from")
+    parser_query.add_argument('--coords', type = str, help = "When running in 'identity' mode do you want 'relative_start', 'relative_center', 'relative_end' or 'absolute' coords? Default = 'absolute'")
     parser_query.add_argument('--upstream', type=int, help = "bp upstream to add")
     parser_query.add_argument('--downstream', type = int, help = "bp downstream to add")
     parser_query.add_argument('--samp_names', type = str, nargs = "+", help = "sample names for each file")
@@ -647,6 +680,9 @@ if __name__ == "__main__":
     parser_compare.add_argument('--res', type=int, default=1,
             help="Resolution to compute statistics at. Default 1bp. Note this \
             should be set no lower than the resolution of the input files")
+    parser_compare.add_argument('--pseudocount', default = 0, type = int,
+            help = "Add value to all unmasked regions before ratio calculations. \
+                    Default = 0 ")
     parser_compare.add_argument('--operation', type=str, default="log2ratio",
             help="Default is log2ratio i.e. log2(infile1) - log2(infile2). Other \
                     options include: add, subtract, divide, recipratio (invert ratios less than 1. Center at 0)")

--- a/workflow/scripts/bwtools.py
+++ b/workflow/scripts/bwtools.py
@@ -317,10 +317,10 @@ def relative_polymerase_progression(array):
 def traveling_ratio(array, res, wsize):
     return arraytools.traveling_ratio(array, wsize = wsize//res)
 
-def traveling_ratio_fixed(array, res, wsize, upstream):
-    if upstream < wsize:
-        raise ValueError("Upstream must be > %s for fixed traveling ratio. Upstream is %s"%(wsize, upstream))
-    return arraytools.traveling_ratio(array, wsize = wsize//res, peak = upstream//res)
+def traveling_ratio_fixed(array, res, wsize, relative_location):
+    if relative_location < wsize:
+        raise ValueError("Relative location (%s) must be > wsize (%s) for fixed traveling ratio."%(relative_location, wsize))
+    return arraytools.traveling_ratio(array, wsize = wsize//res, peak = relative_location//res)
 
 def summit_loc(array, res, wsize, upstream):
     loc = arraytools.relative_summit_loc(array, wsize = wsize//res)
@@ -391,9 +391,9 @@ def query_main(args):
             'max' : np.nanmax,
             'min' : np.nanmin,
             'RPP' : relative_polymerase_progression,
-            'TR' : lambda array: traveling_ratio(array, args.res, 50),
-            'TR_fixed' : lambda array: traveling_ratio_fixed(array, args.res, 50, args.upstream),
-            'summit_loc': lambda array: summit_loc(array, args.res, 50, args.upstream)}
+            'TR' : lambda array: traveling_ratio(array, args.res, args.wsize),
+            'TR_fixed' : lambda array: traveling_ratio_fixed(array, args.res, args.wsize, args.upstream + args.TR_A_center),
+            'summit_loc': lambda array: summit_loc(array, args.res, args.wsize, args.upstream)}
     try:
         summary_func = summary_funcs[args.summary_func]
     except KeyError:
@@ -635,6 +635,8 @@ if __name__ == "__main__":
             'identity' summary. mean, median, max, min supported. Additionally, traveling ratio ('TR') and relative polymerase progression ('RPP'), \
             and 'summit_loc' (local peak identification) are supported. Default = 'mean'", default = "mean")
     parser_query.add_argument('--gzip', action = "store_true", help = "gzips the output if flag is included")
+    parser_query.add_argument('--TR_A_center', type = int, help = "center of window A in fixed traveling ratio. In relative bp to region start")
+    parser_query.add_argument('--wsize', type = int, default = 50, help = "Size of half window in bp for calcs that use windows. Default = 50 bp")
     parser_query.set_defaults(func=query_main)
 
     # compare verb

--- a/workflow/scripts/bwtools.py
+++ b/workflow/scripts/bwtools.py
@@ -314,8 +314,13 @@ def query_summarize_identity(all_bws, samp_names, samp_to_fname, inbed, res, gzi
 def relative_polymerase_progression(array):
     return arraytools.weighted_center(array, only_finite = True, normalize = True) 
 
-def traveling_ratio(array, res, wsize, maxsize):
-    return arraytools.traveling_ratio(array, wsize = wsize//res, length_cutoff = maxsize//res)
+def traveling_ratio(array, res, wsize):
+    return arraytools.traveling_ratio(array, wsize = wsize//res)
+
+def traveling_ratio_fixed(array, res, wsize, upstream):
+    if upstream < wsize:
+        raise ValueError("Upstream must be > %s for fixed traveling ratio. Upstream is %s"%(wsize, upstream))
+    return arraytools.traveling_ratio(array, wsize = wsize//res, peak = upstream//res)
 
 def summit_loc(array, res, wsize, upstream):
     loc = arraytools.relative_summit_loc(array, wsize = wsize//res)
@@ -386,7 +391,8 @@ def query_main(args):
             'max' : np.nanmax,
             'min' : np.nanmin,
             'RPP' : relative_polymerase_progression,
-            'TR' : lambda array: traveling_ratio(array, args.res, 50, 1000),
+            'TR' : lambda array: traveling_ratio(array, args.res, 50),
+            'TR_fixed' : lambda array: traveling_ratio_fixed(array, args.res, 50, args.upstream),
             'summit_loc': lambda array: summit_loc(array, args.res, 50, args.upstream)}
     try:
         summary_func = summary_funcs[args.summary_func]

--- a/workflow/scripts/bwtools.py
+++ b/workflow/scripts/bwtools.py
@@ -172,7 +172,7 @@ def fixed_scale(arrays, fixed_regions = None, res = 1, summary_func = np.nanmean
         fixed_vals.extend(arrays[region["chrm"]][region["start"]//res:region["end"]//res])
     fixed_vals = np.array(fixed_vals)
     scale_val = summary_func(fixed_vals[np.isfinite(fixed_vals)])
-    if scale_factor == 0:
+    if scale_val == 0:
         raise ValueError("Scale factor value was zero. Consider using different regions")
     for chrm in arrays.keys():
         arrays[chrm] = arraytools.normalize_1D(arrays[chrm], 0, scale_val)

--- a/workflow/scripts/combine_frags_per_contig.R
+++ b/workflow/scripts/combine_frags_per_contig.R
@@ -1,0 +1,16 @@
+library(tidyverse)
+
+args <- commandArgs(trailingOnly = TRUE)
+
+read_and_combine_data <- function(args){
+    out <- vector('list', length(args))
+    for (num in seq_along(args)){
+        these_data <- read_tsv(args[num], col_types ="ci")
+        these_data <- these_data %>% mutate(sample_name = basename(args[num]) %>% str_replace("_frags_per_contig.tsv", ""))
+        out[[num]] <- these_data
+    }
+    bind_rows(out)
+}
+
+d <- read_and_combine_data(args)
+write_tsv(d, "results/quality_control/frags_per_contig/all_samples.tsv")

--- a/workflow/scripts/fragments_per_contig.py
+++ b/workflow/scripts/fragments_per_contig.py
@@ -1,0 +1,15 @@
+import sys
+
+
+if __name__ == "__main__":
+    contigs_dict = {}
+    for line in sys.stdin:
+        this_contig = line.split("\t")[2]
+        this_counter = contigs_dict.get(this_contig, 0)
+        this_counter += 1
+        contigs_dict[this_contig] = this_counter
+    sys.stdout.write("contig\tfragments\n")
+    for (key, val) in contigs_dict.items():
+        sys.stdout.write("%s\t%d\n"%(key, val))
+
+

--- a/workflow/scripts/region_level_spearmans.R
+++ b/workflow/scripts/region_level_spearmans.R
@@ -5,7 +5,7 @@ suppressMessages(library(tidyverse))
 # regions
 
 spearman_per_region <- function(d){
-    samples <- colnames(d %>% select(-c(region,coord)))
+    samples <- colnames(d %>% select(-c(region,coord, chrm)))
     out <- list()
     k <- 1
     # do every combination of samples only once


### PR DESCRIPTION
## 0.3.0 - 2023-07-15

### Added
- A `run_annotations` rule to pull an annotation table for each genome specified
  in the config file
- Ability to get relative coordinates out of postprocessing summaries
- Spike-in quality control by reporting fragments per contig per sample
- Ability to specify window sizes to traveling ratio as well as window A center for
  fixed traveling ratios
- Ability to get raw read counts for a given set of windows and samples

### Changes
- Fixed traveling ratio which centers the promoter proximal window at the first
  coordinate of the given region.

### Bug fixes
- Fixed multiqc config file to report fastqc results both before and after
  trimming
- Fixed issue with quality control where PE fragment size determination failed
  when sample sheets had both SE and PE samples

### Changes
- Relaxed size restriction on traveling ratios to be twice the window size. Down
  from 1000 bp

### Bug fixes
- Calculation of the center coordinate for traveling ratios was fixed